### PR TITLE
Security Requirements Update

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -103,6 +103,9 @@ of the Open Telematics API. Open Telematics server implementations should use th
 **Rate-limit API Requests**
 Since every request to the Open Telematics API must be authenticated it is possible to rate-limit Open Telematics API requests per authenticated user. Vendors should implement rate limits on overall API requests per authenticated user, e.g. to avoid one user exhausting server resources of others; however, vendor must not rate-limit any Open Telematics API implementations to rates below what is offered through their other API services for telematics data.
 
+**Prevent Brute-Forcing***
+Authentication (for this version of the API) is tied exclusively to HTTP Basic in each request. This means that each and every API endpoint is an opportunity to brute force any of the user credentials. Open Telematics server implementors must enforce a global rate-limit on authentication attempts for each user. Implementors may also want to consider other mitigations against brute-force attacks on credentials; c.f. [the OWA page on Blocking Brute Force Attacks](https://www.owasp.org/index.php/Blocking_Brute_Force_Attacks).
+
 ***Prevent Server-Error Stacktraces***
 Open Telematics server implementors must ensure that their software is deployed such that it does not include stack traces in any response; e.g. no stacktraces in a 500 server error response.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -106,6 +106,10 @@ Since every request to the Open Telematics API must be authenticated it is possi
 ***Prevent Server-Error Stacktraces***
 Open Telematics server implementors must ensure that their software is deployed such that it does not include stack traces in any response; e.g. no stacktraces in a 500 server error response.
 
+***Prevent Resource Exhaustion by Slow-posting***
+Open Telematics server implementors must ensure that, when receiving data from clients, the server implements short-enough timeouts such that exhaustion of the server resources through malicious client 'slow-posting' is not possible. For more details, consult this [Qualys blog post](https://blog.qualys.com/securitylabs/2011/11/02/how-to-protect-against-slow-http-attacks).
+
+
 ### Open Telematics API Client Security Requirements
 
 **Certificate Pinning**

--- a/apiary.apib
+++ b/apiary.apib
@@ -103,6 +103,9 @@ of the Open Telematics API. Open Telematics server implementations should use th
 **Rate-limit API Requests**
 Since every request to the Open Telematics API must be authenticated it is possible to rate-limit Open Telematics API requests per authenticated user. Vendors should implement rate limits on overall API requests per authenticated user, e.g. to avoid one user exhausting server resources of others; however, vendor must not rate-limit any Open Telematics API implementations to rates below what is offered through their other API services for telematics data.
 
+***Prevent Server-Error Stacktraces***
+Open Telematics server implementors must ensure that their software is deployed such that it does not include stack traces in any response; e.g. no stacktraces in a 500 server error response.
+
 ### Open Telematics API Client Security Requirements
 
 **Certificate Pinning**


### PR DESCRIPTION
Resolves issues:
* #22 by requiring no stack traces in any responses
* #20 by requiring timers to prevent resource exhaustion by slow posting
* #21 by requiring a global rate limit on authentication attempts. As mentioned in the issue (#21) this open up an obvious Denial of Service attack and if the group wants to accept the additional complexity, then we should move to session-based authentication.