### PR TITLE
Add eventDataChecksum to the Duty Status Object

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -363,7 +363,7 @@ Telematics Data Model* for object descriptions as well.
 + multidayBasis     :                                  0 (required, number) - Multiday basis (7 or 8) used by the motor carrier to compute cumulative duty hours
 + outputFileComment : `fake Duty Status Log for testing` (required, string) - A textual field that may be populated with information pertaining to the creation of an ELD output file
 
-+ eventDataChecksum :                                    (required, string) - The hexidecimal value result of a bitwise exclusive OR(XOR) operation using Table 3 of the ELD mandate
++ eventDataChecksum                                      (required, string) - The hexidecimal value result of a bitwise exclusive OR(XOR) operation using Table 3 of the ELD mandate
 
 ### Stop Geographic Details (object)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -363,6 +363,8 @@ Telematics Data Model* for object descriptions as well.
 + multidayBasis     :                                  0 (required, number) - Multiday basis (7 or 8) used by the motor carrier to compute cumulative duty hours
 + outputFileComment : `fake Duty Status Log for testing` (required, string) - A textual field that may be populated with information pertaining to the creation of an ELD output file
 
++ eventDataChecksum :                                    (required, string) - The hexidecimal value result of a bitwise exclusive OR(XOR) operation using Table 3 of the ELD mandate
+
 ### Stop Geographic Details (object)
 
 + id                : `C4CA4238A0B923820DCC509A6F75849B` (required, string) - The unique identifier for the specific Entity object in the system.


### PR DESCRIPTION
OTAPI shouldn't have to  do the calculation, but we should be able to receive the output of the ELD's validation process - i.e. a valid checksum. I think it would be a nice-to-have for OTAPI to verify the result of the ELD event log against Table 3 of the ELD mandate.