### PR TITLE
Split up data export, add feed follow for fleet info and more

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -598,7 +598,6 @@ Telematics Data Model* for object descriptions as well.
 + eventStart        :          `2019-01-0100:00:00.000Z` (required, string) - Date and time of the start of this driver performance summary
 + eventEnd          :          `2019-01-0100:00:00.000Z` (required, string) - Date and time of the end of this driver performance summary
 + driverId          : `63A9F0EA7BB98050796B649E85481845` (required, string) - The id of the driver for this performance summary
-+ thresholds                                             (required, Performance Thresholds) - the thresholds that were active during this event
 + distance                                               (number) - the total distance covered during this event, in m
 + fuel                                                   (number) - the total fuel consumed during this event, in litres
 + cruiseTime                                             (number) - the total time spent with cruise control engaged during this event, in seconds

--- a/apiary.apib
+++ b/apiary.apib
@@ -565,6 +565,10 @@ Telematics Data Model* for object descriptions as well.
 + overspeedHiThrottle                                    (boolean)          - the total amount of time spent over the speed thresshold and simultaneously above the throttle threshold, in seconds
 + overrpmLowThrottle                                     (boolean)          - the total amount of time spent over the rpm threshold and simultaneously below the throttle threshold, in seconds
 + overrpmHiThrottle                                      (boolean)          - the total amount of time spent over the rpm threshold and simultaneously above the throttle threshold, in seconds
++ lkaActive                                              (boolean)          - Lane Keep Assist active status
++ lkaDisable                                             (boolean)          - Lake Keep Assist disable switch status
++ ldwActive                                              (boolean)          - Lane Departure Warning active status
++ ldwDisable                                             (boolean)          - Lane Departure Warning disabel switch status
 
 ### Vehicle Fault Code Event (object)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -205,11 +205,23 @@ The total number of elements available is returned in the `X-Total-Count` respon
 # Server Performance
 
 This API is intended to be integrated into motor freight carriers back end operations systems; therefore, there are
-performance requirements to be considered also. The API has been modeled in terms of use cases by the motor freight
+performance requirements to be considered as well. The API has been modeled in terms of use cases by the motor freight
 carriers (see below). Each of these use cases can be considered to be executing concurrently in the motor freight
-carrier. For large motor freight carriers, each use case interacts with TSP servers at up to 10,000 requests per minute.
+carrier. This has important design implications. For example, if a motor freight carrier has 10,000 trucks and makes
+requests regarding their location once a minute this would imply 10,000 method invocations per minute with a relatively
+small return data point. Other methods such as vehicle histories will have larger return data sets and require more
+server side processing but would not be expected to be called with a high frequency. Given that it is not possible to
+understand how these methods might be used by motor freight carriers in a final implementation it is difficult to
+provide concrete performance metric requirements at this stage. Instead, implementors should consider this per-truck
+scaling and design accordingly. i.e. consider that fleets can have more than 100,000 trucks and that some API endpoints
+in this specification will be called rapidly (1 request per minute) whereas others will be called infrequently (1
+request per day).
 
-Therefore, server implementations of this API are expected to be able to serve 10,000 requests per minute per use case.
+This specification does not go into implementation specific design decisions which are up to the individual TSPs since
+such decisions are heavily dependent on their architecture. It is, however, strongly recommended that the TSPs consider
+building-in performance features such as request queueing and request rate limiters to provide a stable and robust
+solution. It is also recommended that the TSPs provide information on the frequency of updates for data feed
+subscriptions such as the vehicle feed so the consumers can make appropriate design decisions.
 
 # Unknown Drivers
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -184,8 +184,9 @@ given by the pair of `start` and `stop` parameters.
 
 # Working With Locations
 
-When exchanging locations as parameters to API methods or in responses from the API, you must ensure
-that they are formatted as a latitude+longitude pair (format `[-]aaa.aaaaaaa [-]ooo.ooooooo`).
+When exchanging locations as parameters to API methods or in responses from the API, you must ensure that they are
+formatted as a latitude+longitude pair (format `[-]aaa.aaaaaaa [-]ooo.ooooooo`). Positive in the first component,
+Latitude, indicates North (N) and East (E) in the second component, Longitude.
 
 # Error States
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2140,6 +2140,8 @@ time period. They query the API for
 
 of all vehicles over a given time period.
 
+For certain use cases, they may opt to *follow* a feed of the above objects instead. See *Follow Fleet Vehicle Info* below.
+
 They may also follow-up with queries of the hi-resolution time history of the fleet for a given time period:
 
 * Vehicle Location Time History
@@ -2154,7 +2156,7 @@ Clients can retrieve a combination of all vehicle information for all vehicles o
 
 |Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
 |-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | **DENY**   | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
 
 + Parameters
     + version: `v1` (enum[string]) - API version
@@ -2183,6 +2185,48 @@ Clients can retrieve a combination of all vehicle information for all vehicles o
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
+
+## Follow Fleet Vehicle Info [GET /api{version}/vehicleinfos/feed{?token}]
+
+Clients can follow a feed of a combination of all vehicle information for all vehicles as they are added to the TSP
+system; following is accomplished via polling an endpoint and providing a 'token' which evolves the window of new
+entries with each query in the polling.
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Duty Status Logs; pass in a `null` or omit this token to start with a new token set to 'now'.
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Duty Status Logs
+        + feed                                  (object) - the 'feed' of Fleet Vehicle Info
+            + coarseVehicleLocationTimeHistories                 (required, Coarse Vehicle Location Time History) - The Coarse Vehicle Location Time History for all vehicles in the requested time period
+            + flaggedVehiclePerformanceEvents                    (required, array[Flagged Vehicle Performance Event], fixed-type) - all flagged vehicle performance events for all vehicles in the requested time period
+            + vehiclePerformanceEvents                           (required, array[Vehicle Performance Event], fixed-type) - all vehicle performance events for all vehicles in the requested time period
+            + vehicleFaultCodeEvents                             (required, array[Vehicle Fault Code Event], fixed-type) - all vehicle fault code events for all vehicles in the requested time period        
+
++ Response 400 (text/plain)
+
+        Error: token parameter invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
 
 # Group Use Case Compliance and Safety Monitoring
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -191,6 +191,16 @@ that they are formatted as a latitude+longitude pair (format `[-]aaa.aaaaaaa [-]
 
 The common [HTTP Response Status Codes](https://github.com/for-GET/know-your-http-well/blob/master/status-codes.md) are used.
 
+# Pagination
+
+Where requests may return large collections and where the collections to be returned are presumed to be static the API
+will include support for pagination of requests. The scheme for pagination closely follows [the pagination scheme of github](https://developer.github.com/v3/#pagination).
+
+Requests that are paginated will return 50 items by default. The `page` parameter can be used to access later pages;
+it defaults to the first page, page *1*. A custom number of items can be requested with the `count` parameter.
+
+The total number of elements available is returned in the `X-Total-Count` response header.
+
 # Server Performance
 
 This API is intended to be integrated into motor freight carriers back end operations systems; therefore, there are
@@ -621,27 +631,6 @@ Telematics Data Model* for object descriptions as well.
 + dateTime: `2019-01-0100:00:00.000Z`                    (required, string) - Date and time of this service status
 + factors: `upstream server operational`, `authentication service operational` (array[string], fixed-type) - a list of contributing factors to the current service status. Providers may use this to communicate details about loss of service
 
-### Vehicle Only Complete Telematics Records (object)
-
-+ stopGeographicDetails                                  (array[Stop Geographic Details], fixed-type) - All of the Stop Geographic Details objects known to the TSP at the time of the request
-+ performanceThresholds                                  (array[Performance Thresholds], fixed-type) - All of the Performance Thresholds objects known to the TSP at the time of the request
-+ vehicles                                               (array[Vehicle], fixed-type) - All of the Vehicle objects known to the TSP at the time of the request
-+ vehicleLocationTimeHistories                           (array[Vehicle Location Time History], fixed-type) - Any of the Vehicle Location Time History objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ vehicleFlaggedEvents                                   (array[Vehicle Flagged Event], fixed-type) - Any of the Vehicle Flagged Event objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ vehiclePerformanceEvents                               (array[Vehicle Performance Event], fixed-type) - Any of the Vehicle Performance Event objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ flaggedVehiclePerformanceEvents                        (array[Flagged Vehicle Performance Event], fixed-type) - Any of the Flagged Vehicle Performance Event objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ vehicleFaultCodeEvents                                 (array[Vehicle Fault Code Event], fixed-type) - Any of the Vehicle Fault Code Event objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ stateOfHealths                                         (array[State of Health], fixed-type) - Any of the State of Health objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-
-### Complete Telematics Records (Vehicle Only Complete Telematics Records)
-
-+ drivers                                                (array[Driver], fixed-type) - All of the Driver objects known to the TSP at the time of the request
-+ annotationLogs                                         (array[Annotation Log], fixed-type) - Any of the Annotation Log objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ dutyStatusLogs                                         (array[Duty Status Log], fixed-type) - Any of the Duty Status Log objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ regionSpecificBreaksRules                              (array[Region Specific Breaks Rules], fixed-type) - Any of the Region Specific Breaks Rules objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ regionSpecificWaivers                                  (array[Region Specific Waivers], fixed-type) - Any of the Region Specific Waivers objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-+ driverPerformanceSummaries                             (array[Driver Performance Summary], fixed-type) - Any of the Driver Performance Summary objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
-
 ## Data Structures
 
 ### Open Telematics TSP Inbound Objects (object)
@@ -790,17 +779,63 @@ TSP outage or for research purposes offline or to restore data -- although this 
 we aim to support here please see below on 'data import.'
 
 The IT staff and automated systems want to retrieve a complete record of all TSP-hosted data (with caveat notes above)
-for a given time-period. They do this by querying for either
+for a given time-period. They do this by querying for sets of the following data types over a given period of time:
 
-* Complete Telematics Records OR Vehicle-Only Telematics Records
-
-for a given period of time.
+* Vehicle
+* Vehicle Location Time History
+* Vehicle Flagged Event
+* Vehicle Performance Event
+* Flagged Vehicle Performance Event
+* Performance Thresholds
+* Stop Geographic Details
+* Vehicle Fault Code Event
+* Driver
+* Annotation Log
+* Duty Status Log
+* Region Specific Breaks Rules
+* Region Specific Waivers
+* Driver Performance Summary
+* State of Health
 
 The carriers would also like to be able to use the exported data in an 'import' to a second TSP or new instances of the
 same TSP. This is not an use case which this specification will attempt to support; however, we will aim to design the
 data structures such that any TSP wanting to implement _import_ is enabled to do so (c.f. 'Provider ID').
 
-## Complete Telematics Records Export Format [/api{version}/export/allrecords{?start,stop}]
+The following methods are defined to enable clients to retrieve the entirety of all Telematics data from the TSP for a given time period.
+
+The response to the request will include both time-varying objects (those that have time associated with them) and also
+those that do not.
+
+* For time-varying objects: the responses will only include whose associated time periods have an intesection with the
+requested time period (as per the details of the *Working With Dates* section above);
+
+* For non time-varying objects: the response will include all objects known to the TSP at the time of the request,
+regardless of the time period requested as defined by `start` and `stop` query parameters (included on the endpoints for
+API consistency under `/export/...`)
+
+***Vehicle-Only Data Export***
+
+To export data that does not deal with driver PII, the motor freight carrier can request sets of the following data
+types (see below for details on how to request). As is noted in the access controls below, requests for these data types
+deny access by the *Vehicle X* roles.
+
+* Stop Geographic Details
+* Performance Thresholds
+* Vehicle
+* Vehicle Location Time History
+* Vehicle Flagged Event
+* Vehicle Performance Event
+* Flagged Vehicle Performance Event
+* Vehicle Fault Code Event
+* State of Health
+
+## Export of all Vehicle objects [GET /api{version}/export/vehicles{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
 
 + Parameters
     + version: `v1` (enum[string]) - API version
@@ -808,24 +843,11 @@ data structures such that any TSP wanting to implement _import_ is enabled to do
             + `v1`
     + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
     + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
 
-+ Attributes (Complete Telematics Records)
-
-### Retrieve Complete Telematics Records for a Given Time Period [GET]
-
-Clients can retrieve the entirety of all Telematics data from the TSP for a given time period.
-
-The response to this request will include both time-varying objects (those that have time associated with them) and also
-those that do not. The response will only include those time-varying objects whose associated time periods have an
-intesection with the requested time period (as per the details of the *Working With Dates* section above); the response
-will also include the entire list of all non time-varying objects known to the TSP at the time of the request,
-regardless of the time period requested as defined by `start` and `stop` query parameters.
-
-**Access Controls**
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
 
 + Request
     + Headers
@@ -833,7 +855,12 @@ regardless of the time period requested as defined by `start` and `stop` query p
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (Complete Telematics Records)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
 
 + Response 400 (text/plain)
 
@@ -844,7 +871,13 @@ regardless of the time period requested as defined by `start` and `stop` query p
 
             WWW-Authenticate: Basic realm="protected"
 
-## Vehicle-Only Complete Telematics Records Export Format [/api{version}/export/vehiclerecords{?start,stop}]
+## Export of all Vehicle Location Time History objects     [GET /api{version}/export/coarsevehiclelocations{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
 
 + Parameters
     + version: `v1` (enum[string]) - API version
@@ -852,25 +885,11 @@ regardless of the time period requested as defined by `start` and `stop` query p
             + `v1`
     + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
     + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
 
-+ Attributes (Vehicle Only Complete Telematics Records)
-
-### Retrieve Vehicle-Only Complete Telematics Records for a Given Time Period [GET]
-
-Clients can retrieve the entirety of all Telematics data from the TSP -- that data which does not deal with Driver PII
--- for a given time period.
-
-The response to this request will include both time-varying objects (those that have time associated with them) and also
-those that do not. The response will only include those time-varying objects whose associated time periods have an
-intesection with the requested time period (as per the details of the *Working With Dates* section above); the response
-will also include the entire list of all non time-varying objects known to the TSP at the time of the request,
-regardless of the time period requested as defined by `start` and `stop` query parameters.
-
-**Access Controls**
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
 
 + Request
     + Headers
@@ -878,8 +897,546 @@ regardless of the time period requested as defined by `start` and `stop` query p
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (Vehicle Only Complete Telematics Records)
+    + Headers
 
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle Location Time History], fixed-type) - array of all objects which match the date parameters in the query
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Vehicle Flagged Event objects             [GET /api{version}/export/vehicleflaggedevents{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Vehicle Performance Event objects         [GET /api{version}/export/vehicleperformanceevents{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Flagged Vehicle Performance Event objects [GET /api{version}/export/flaggedvehicleperformanceevents{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Performance Thresholds objects            [GET /api{version}/export/performancethresholds{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Stop Geographic Details objects           [GET /api{version}/export/steopgeographicdetails{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Vehicle Fault Code Event objects          [GET /api{version}/export/faultcodeevents{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Driver objects                            [GET /api{version}/export/drivers{?start,stop,page,count}]
+
+**Access Controls**
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Annotation Log objects                    [GET /api{version}/export/annotationlogevents{?start,stop,page,count}]
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Duty Status Log objects                   [GET /api{version}/export/eventlogobjects{?start,stop,page,count}]
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Region Specific Breaks Rules objects      [GET /api{version}/export/regionspecificbreakrules{?start,stop,page,count}]
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Region Specific Waivers objects           [GET /api{version}/export/regionspecificwaivers{?start,stop,page,count}]
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all Driver Performance Summary objects        [GET /api{version}/export/driverperformancesummaries{?start,stop,page,count}]
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
+
++ Response 400 (text/plain)
+
+        Error: start or stop parameters invalid
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
+## Export of all State of Health objects                   [GET /api{version}/export/serverstateofhealths{?start,stop,page,count}]
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + version: `v1` (enum[string]) - API version
+        + Members
+            + `v1`
+    + start: `2019-01-0100:00:00.000Z` (required, string) - the start-date of the search
+    + stop:  `2019-01-0100:00:00.000Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (object)
+        + data                             (required, array[Vehicle], fixed-type) - array of all objects which match the date parameters in the query.
 
 + Response 400 (text/plain)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -454,8 +454,8 @@ Telematics Data Model* for object descriptions as well.
 + engineRPM                                              (required, number) - engine RPMs at time of event, in revolutions per minute
 + accelerationPercent:                                0  (required, number) - vehicle commanded acceleration, in percent
 + seatBelts         :                               true (boolean) -  Were seat belts engaged at time of event
-+ cruiseStatus                                           (required, Cruise Status) - the cruise status at the time of this event
-+ parkingBreak      :                             false  (required, boolean) - parking break status at time of event
++ cruiseStatus                                           (optional, Cruise Status) - the cruise status at the time of this event
++ parkingBreak      :                             false  (optional, boolean) - parking break status at time of event
 + ignitionStatus                                         (required, Ignition Status) - the ignition status at the time of the event
 + forwardVehicleSpeed:                                1  (required, number) - vehicle speed according to tire rotation, in m/s
 + forwardVehicleDistance:                           100  (required, number) - vehicle distance traveled since cycled, in m

--- a/apiary.apib
+++ b/apiary.apib
@@ -294,7 +294,7 @@ Telematics Data Model* for object descriptions as well.
 + id                : `C4CA4238A0B923820DCC509A6F75849B` (required, string) - The unique identifier for the specific Entity object in the system.
 + providerId        :                 `api.provider.com` (required, string) - The unique 'Provider ID' of the TSP.
 + annotations                                            (array[Annotation Log], fixed-type) - The list of AnnotationLog(s) which are associated with this log.
-+ coDrivers         : `A87FF679A2F3E71D9181A67B7542122C`, `E4DA3B7FBBCE2345D7772B0674A318D5` (array[string], fixed-type) - The list of the co-driver User(s) for this log.
++ coDrivers         : `A87FF679A2F3E71D9181A67B7542122C`, `E4DA3B7FBBCE2345D7772B0674A318D5` (array[string], fixed-type) - The list of the co-driver User(s) for this log; may only be populated in day end log events
 + dateTime       :             `2019-01-0100:00:00.000Z` (required, string) - Date and time from the telematics device
 + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id associated with this log.
 + driverId          : `63A9F0EA7BB98050796B649E85481845` (required, string) - The id of the driver who created this log.

--- a/apiary.apib
+++ b/apiary.apib
@@ -211,6 +211,12 @@ carrier. For large motor freight carriers, each use case interacts with TSP serv
 
 Therefore, server implementations of this API are expected to be able to serve 10,000 requests per minute per use case.
 
+# Unknown Drivers
+
+For the elements of Open Telematics API which are concerned with Driver log events, or other driver-associated data,
+there needs to be a concept of an 'unknown driver'. Indeed this concept is part of the ELD mandate. In Open Telematics
+API objects: `driverID` references to the unknown driver is represented by `null`.
+
 # Provider Identifiers
 
 An important use case of the Open Telematics API by motor freight carriers is to run 'mixed fleets' where there are more


### PR DESCRIPTION
I've updated https://previewotapi.docs.apiary.io/ to show a rendering of all the changes in this PR. Go there for pretty docs; see the 'Files Changed' tab for the differences.

This changeset resolves the following issues:
* split up data export into multiple endpoints  -- #74
* support pagination on large collection-returning API endpoints  -- #48
* add a 'follow' action for custom business intelligence use case  -- #68
* ensure that per-tractor thresholds are in valid places in the data model  -- #80
* include representations for unknown drivers  -- #87
* updates to performance requirements  -- #86
* mark cruise status and parking break as optional  -- #70
* mark co-drivers field as optional and improve field desc  -- #64
* note +ve directions in lat / long  -- #63
* add vehicle performance events fields for ADAS  -- #61