### PR TITLE
Exports being processed should return 202 instead of 204

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1081,7 +1081,7 @@ Only Complete Telematics Records Daily Export Format* for more details.
 ### Poll for Availability of Daily Complete Telematics Records [GET]
 
 If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
-ready then a `204` return code will be returned.
+ready then a `202` return code will be returned.
 
 **Access Controls**
 
@@ -1124,7 +1124,7 @@ ready then a `204` return code will be returned.
 ### Poll for Availability of Daily Complete Telematics Records [GET]
 
 If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
-ready then a `204` return code will be returned.
+ready then a `202` return code will be returned.
 
 **Access Controls**
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1098,7 +1098,7 @@ ready then a `202` return code will be returned.
     + Attributes (object)
         + location: `https://api.provider.com/api{version}/export/allrecords/files/d8603741fd48a71cbf8546b04c9bc9f8` (required, string) - a URL where the complete file can be retrieved. If it is under that of the OTAPI endpoints then the same authentication and authorization schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible without any authentication or authorization and the client is expected to be configured with the appropriate credentials for download independently of responses from the OTAPI server.
 
-+ Response 204
++ Response 202
 
 + Response 400 (text/plain)
 
@@ -1141,7 +1141,7 @@ ready then a `202` return code will be returned.
     + Attributes (object)
         + location: `https://api.provider.com/api{version}/export/vehiclerecords/files/d8603741fd48a71cbf8546b04c9bc9f8` (required, string) - a URL where the complete file can be retrieved. If it is under that of the OTAPI endpoints then the same authentication and authorization schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible without any authentication or authorization and the client is expected to be configured with the appropriate credentials for download independently of responses from the OTAPI server.
 
-+ Response 204
++ Response 202
 
 + Response 400 (text/plain)
 


### PR DESCRIPTION
204 indicates the request has been fulfilled and there is no content for the client. 202 indicates the request is still being processed. Proposed change from #119.