### PR TITLE
changes to address latency use case, event speed thresholds, and more

### DIFF
--- a/APIMATIC-META.json
+++ b/APIMATIC-META.json
@@ -13,7 +13,7 @@
     "ModelSerializationScheme": "Json",
     "ArraySerialization": "Indexed",
     "Nullify404": false,
-    "UseHttpMethodPrefix": true,
+    "UseHttpMethodPrefix": false,
     "UseModelPrefix": false,
     "UseExceptionPrefix": true,
     "UseEnumPrefix": true,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,35 @@
 # Open Telematics API
 
-API Blueprint for Open Telematics API
+A project to enable business resiliency for motor freight carriers with tight integrations into Telematics Service Providers (TSPs).
 
-Connected to apiary.io : visit https://opentelematicsapi.docs.apiary.io/# for a live rendering of `apiary.apib`
+![NMFTA Logo](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/image1.png)
+
+This repository hosts the `v0.1-rc.5` draft formal specification of the Open Telematics API; in [API Blueprint format 1A](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md).
+
+The draft specification is pubished in various forms:
+
+* here, in [`apiary.apib`](https://github.com/nmfta-repo/nmfta-opentelematics-api/blob/master/apiary.apib)
+* at [opentelematicsapi.docs.apiary.io](https://opentelematicsapi.docs.apiary.io) as:
+	* Interactive documentation
+	* A mock server
+* at [apimatic/.../nmfta-opentelematics-api](https://www.apimatic.io/apidocs/nmfta-opentelematics-api) as:
+	* Exportable API specifications in multiple formats including: Open API 3.0, RAML 1.0, and Swagger 2.0
+	* Downloadable (client) SDKs in .NET and Python
+
+# Contributors
+
+This Open Telematics API was made possible through the generous contributions of thought leadership and technical expertise
+of many collaborators across the heavy vehicle cyber security community, working to push the industry forward and make it
+more resilient. Though some of our contributors wish to remain anonymous, we are deeply grateful to everyone who has given
+their time and energy to make this a reality.
+
+
+| **Fleet Managers** | **Telematics Providers** | **Independents**                                                |
+|:------------------:|:------------------------:|:---------------------------------------------------------------:|
+| Bill Brown, SEFL   | Geotab                   | Altaz Valani, Security Compass                                  |
+|Penske Truck Leasing| Samsara Networks, Inc.   | Stephen Raio, U.S. Army Combat Capabilities Development Command |
+|                    | Omnitracs                | Andrew Smith, ISE Inc.                                          |
+|                    |                          | Dr. Jeremy Daily, UTulsa                                        |
+
+![SEFL](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/SFL2c_300dpi-resized.jpg) ![Geotab](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/geotab-logo_full-colour-rgb_resized.png) ![Samsara Networks Inc.](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/samsara_horizontal_logo_black-resized.jpg) ![Security Compass](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/securitycompass-logo-resized.jpg) ![ISE Inc.](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/ISE_A_Trimble_Company_RGB.png) ![Omnitracs](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/Omnitracs_logo_2015_CMYK_no_tagline.jpg)
+

--- a/apiary.apib
+++ b/apiary.apib
@@ -689,9 +689,6 @@ Telematics Data Model* for object descriptions as well.
 
 ### Performance Thresholds (object)
 
-+ id                : `C4CA4238A0B923820DCC509A6F75849B` (required, string) - The unique identifier for the specific Entity object in the system.
-+ providerId        :                 `api.provider.com` (required, string) - The unique 'Provider ID' of the TSP
-+ serverTime        :             `2019-04-05T02:04:16Z` (required, string) - Date and time when this object was received at the TSP
 + activeFrom        :             `2019-04-05T02:04:16Z` (required, string) - The date and time these thresholds take effect
 + activeTo          :             `2019-04-05T02:04:16Z` (string)           - The date and time these thresholds stop taking effect, if left blank then the rules apply in perpetuity
 + rpmOverValue                                           (number)           - the configured RPM threshold, above which engine RPM readings are considered 'over', in revolutions per minute
@@ -860,7 +857,6 @@ Telematics Data Model* for object descriptions as well.
 ### Vehicle Only Complete Telematics Records (object)
 
 + stopGeographicDetails                                  (array[Stop Geographic Details], fixed-type) - All of the Stop Geographic Details objects known to the TSP at the time of the request
-+ performanceThresholds                                  (array[Performance Thresholds], fixed-type) - All of the Performance Thresholds objects known to the TSP at the time of the request
 + vehicles                                               (array[Vehicle], fixed-type) - All of the Vehicle objects known to the TSP at the time of the request
 + vehicleLocationTimeHistories                           (Vehicle Location Time History, fixed-type) - Any of the Vehicle Location Time History objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
 + vehicleFlaggedEvents                                   (array[Vehicle Flagged Event], fixed-type) - Any of the Vehicle Flagged Event objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
@@ -1087,7 +1083,6 @@ Daily Export Format* below for more details.
 * Vehicle Location Time History
 * Vehicle Flagged Event
 * Vehicle Performance Event
-* Performance Thresholds
 * Stop Geographic Details
 * Vehicle Fault Code Event
 * Driver
@@ -1103,7 +1098,6 @@ The *Vehicle Only Complete Telematics Records* objects will contain only the fol
 Only Complete Telematics Records Daily Export Format* for more details.
 
 * Stop Geographic Details
-* Performance Thresholds
 * Vehicle
 * Vehicle Location Time History
 * Vehicle Flagged Event
@@ -3265,40 +3259,6 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 
 + Response 200 (application/json)
     + Attributes (Flagged Vehicle Fault Code Event)
-
-+ Response 401
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-## Performance Thresholds Object                                   [/v1.0/fleet/performance_thresholds/{id}]
-
-+ Parameters
-    + id            (string) - ID of the Performance Thresholds of interest
-
-+ Attributes (Performance Thresholds)
-
-### Get a Performance Thresholds by its ID                     [GET]
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (Performance Thresholds)
 
 + Response 401
     + Headers

--- a/apiary.apib
+++ b/apiary.apib
@@ -541,7 +541,7 @@ for the time period from the driver's start of route up until the present by usi
 
 To change the route they use
 
-* [Update Driver Route Stop](#update_driver_route_stop) for a given [Vehicle object id](#vehicle_object) and a given *Vehicle Route object id*
+* [Update Vehicle Route](#update_vehicle_route) for a given [Vehicle object id](#vehicle_object) and a given *Vehicle Route object id*
 
 To update details (entry points, notes) of the route stop they use
 
@@ -582,7 +582,7 @@ completed trip, along with the driver information about duty on the trip. They h
 
 * a [Driver object id](#driver_object) for a given driver
 * and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) and may have optionally
-[updated the driver's Route Stop](#update_driver_route_stop) or [updated the *Stop Geographic Details*](#update_stop_geographic_details)
+[updated the driver's Route Stop](#update_vehicle_route) or [updated the *Stop Geographic Details*](#update_stop_geographic_details)
 they hence have both
     * a *Vehicle Route object id* and
     * a [Stop Geographic Details object id](#stop_geographic_details_object).
@@ -1224,110 +1224,370 @@ data type defined below. If you change one you should probably also change the o
 + password                                               (string) - user password
 + enabled           :                             `true` (boolean) - this user is enabled or disabled
 
-# Group Use Case Check Provider State of Health
 
-## Check Current State of Health                               [GET /v1.0/health/current]
-<a id="check_current_state_of_health"></a>
+# Group Vehicle
 
-Clients can request the current service state of health. The response to this query will be a data structure indicating
-everything is good or showing some details as to why the service is not presently at 100%.
+## Create a Vehicle Route                                     [POST /v1.0/vehicles/{vehicleId}/routes]
+<a id="create_a_vehicle_route"></a>
 
-Clients must treat any response other than code 200, code 401, or code 429 as equivalent to `SERVICESTATUS_MAJOR_OUTAGE`.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | ALLOW      | ALLOW      | ALLOW      |
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (State of Health)
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-## Check Past 30d State of Health                              [GET /v1.0/health/recents]
-<a id="check_past_30d_state_of_health"></a>
-
-Clients can request the recent history of all service statuses. The response to this query will return all service
-status records (i.e. those returned via [Check Current State of Health](#check_current_state_of_health)) from over th
-past 30 days.
-
-Clients must treat any response other than code 200, code 401, or code 429 as equivalent to `SERVICESTATUS_MAJOR_OUTAGE`.
+Clients can request the creation of a new route for a given vehicle, providing start & stop location along with
+additional instructions in a *Externally Sourced Route Start Stop Details* object.
 
 **Access Controls**
 
 
 |Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
 |-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | ALLOW      | ALLOW      | ALLOW      |
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + data (array[State of Health], fixed-type)
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-# Group Use Case Data Export
-
-## Complete Telematics Export Format                               [/v1.0/export/allrecords/status{?dayOf}]
-<a id="complete_telematics_export_format"></a>
+|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
 
 + Parameters
-    + dayOf:    `2019-04-05T02:04:16Z` (required, string) - the day of interest, specified by any timestamp within that day, including 0000h
+    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
 
-+ Attributes (Complete Telematics Records)
++ Request
+    + Headers
 
-### Test if Complete Export Ready                              [GET]
-<a id="test_if_complete_export_ready"></a>
+            Authorization: Basic YWRtaW46YWRtaW4=
 
-If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
-ready then a `202` return code will be returned.
+    + Attributes (Externally Sourced Route Start Stop Details)
+
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "ExternallySourcedRouteStartStopDetails",
+                "required": [
+                  "startName",
+                  "startLocation",
+                  "stopName",
+                  "stopLocation"
+                ],
+                "type": "object",
+                "properties": {
+                  "startName": {
+                    "type": "string",
+                    "description": "a name for the start location",
+                    "example": "start place 202"
+                  },
+                  "startAddress": {
+                    "type": "string",
+                    "description": "an optional street address of the start",
+                    "example": "11 Elm Street"
+                  },
+                  "startLocation": {
+                    "type": "string",
+                    "description": "the location of the start",
+                    "example": "37.4224764 -122.0842499"
+                  },
+                  "routeAddInstructions": {
+                    "type": "string",
+                    "description": "an optional comment with details about the route",
+                    "example": "take trailers XXX and YYY"
+                  },
+                  "stopName": {
+                    "type": "string",
+                    "description": "a name for the stop location",
+                    "example": "pickup place 101"
+                  },
+                  "stopAddress": {
+                    "type": "string",
+                    "description": "an optional street address",
+                    "example": "13 Sycamore Ave"
+                  },
+                  "stopLocation": {
+                    "type": "string",
+                    "description": "the location of the stop",
+                    "example": "37.4224764 -122.0842499"
+                  },
+                  "stopDeadline": {
+                    "type": "string",
+                    "description": "optional time and date when the stop must be arrived at",
+                    "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})[+-](\\d{2})\\:(\\d{2})$",
+                    "example": "2019-04-05T02:04:16Z"
+                  }
+                }
+            }
+
++ Response 201 (application/json)
+
+    + Attributes (object)
+        + routeId       : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route created, to be used for later updates to the route
+        + stopId        : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - the id of the stop in the created route (most likely a re-used location), to be use for later updates to Stop Geograhic Details
+
++ Response 204
+
++ Response 404 (text/plain)
+
+        Error: vehicleId Not Found
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Update Vehicle Route                                        [PUT /v1.0/vehicles/{vehicleId}/routes/{routeId}]
+<a id="update_vehicle_route"></a>
+
+Clients can update a Driver's destination; sending data to this endpoint, using a previously obtained `routeId` will
+change the destination of the route, hence also changing the stopId associated with the route.
 
 **Access Controls**
 
 
 |Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
 |-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
+    + routeId           : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route created, to be used for later updates to the route
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
+    + Attributes (Externally Sourced Route Stop Details)
+
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "ExternallySourcedRouteStopDetails",
+                "required": [
+                  "stopName",
+                  "stopLocation"
+                ],
+                "type": "object",
+                "properties": {
+                  "stopName": {
+                    "type": "string",
+                    "description": "a name for the stop location",
+                    "example": "pickup place 101"
+                  },
+                  "stopAddress": {
+                    "type": "string",
+                    "description": "an optional street address",
+                    "example": "13 Sycamore Ave"
+                  },
+                  "stopLocation": {
+                    "type": "string",
+                    "description": "the location of the stop",
+                    "example": "37.4224764 -122.0842499"
+                  },
+                  "stopDeadline": {
+                    "type": "string",
+                    "description": "optional time and date when the stop must be arrived at",
+                    "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})[+-](\\d{2})\\:(\\d{2})$",
+                    "example": "2019-04-05T02:04:16Z"
+                  }
+                }
+              }
+
++ Response 200 (application/json)
+
+    + Attributes (object)
+        + routeId       : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route updated, to be used for later updates to the route
+        + stopId        : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - the id of the stop in the updated route (most likely a re-used location), to be use for later updates to Stop Geograhic Details
+
++ Response 204
+
++ Response 404 (text/plain)
+
+        Error: vehicleId or routeId Not Found
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Update Stop Geographic Details                           [PATCH /v1.0/stops/{stopId}]
+<a id="update_stop_geographic_details"></a>
+
+Clients can update the _geographic details_ of a stop; the *Stop Geographic Details* are the specific location for the
+truck and trailer to park and a polygon of geographic points indicating the entryway onto a facility (i.e. where the
+truck should drive on approach).
+
+Sending data to this endpoint, using a previously returned `stopId` will update the geograhic details of the stop and
+any other routes using this stop will also be updated.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + stopId           : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - The stop id to update
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
+    + Attributes (Externally Sourced Stop Geographic Details)
+
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "ExternallySourcedStopGeographicDetails",
+                "required": [
+                  "location"
+                ],
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string",
+                    "description": "an optional comment"
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "the location of the delivery date at this stop",
+                    "example": "37.4224764 -122.0842499"
+                  },
+                  "entryArea": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "optional geographic location polygon detailing the entryway area for this stop"
+                  }
+                }
+            }
+
++ Response 200 (application/json)
+
+    + Attributes (object)
+        + stopId        : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - the id of the stop that was updated, to be used for later updates to Stop Geograhic Details
+
++ Response 204
+
++ Response 404 (text/plain)
+
+        Error: stopId Not Found
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Send Message to a Vehicle                                  [POST /v1.0/vehicles/{vehicleId}/message]
+<a id="send_message_to_a_vehicle"></a>
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to send the message to
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
+    + Attributes (Externally Sourced Vehicle Display Messages)
+
+    + Schema
+
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "ExternallySourcedVehicleDisplayMessages",
+                "required": [
+                  "message"
+                ],
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "type": "string",
+                    "description": "a brief 'subject-line' for this message"
+                  },
+                  "message": {
+                    "type": "string",
+                    "description": "the message to be displayed to the driver"
+                  }
+                }
+            }
+
++ Response 201 (application/json)
+    + Attributes (object)
+        + messageReceiptId:   `FC5E038D38A57032085441E7FE7010B0` (required, string) - the id of the Message Receipt object that will track the delivery- and option display-timestamps of this message
+
++ Response 204
+
++ Response 404 (text/plain)
+
+        Error: vehicleId not found
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Get Vehicle Flagged Events                                  [GET /v1.0/vehicles/{vehicleId}/flagged_events/{?startTime,stopTime}]
+<a id="get_vehicle_flagged_events"></a>
+
+Clients can retrieve all the flagged vehicle events of a given vehicle over a given period of time.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
+    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
+    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
 
 + Request
     + Headers
@@ -1335,16 +1595,15 @@ ready then a `202` return code will be returned.
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + location: `https://api.provider.com/v1.0/export/allrecords/files/d8603741fd48a71cbf8546b04c9bc9f8` (required, string) - a URL where the complete file can be retrieved. If it is under that of the OTAPI endpoints then the same authentication and authorization schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible without any authentication or authorization and the client is expected to be configured with the appropriate credentials for download independently of responses from the OTAPI server.
-
-+ Response 202
-
-        File not yet ready for download
+    + Attributes (Vehicle Flagged Event)
 
 + Response 400 (text/plain)
 
-        Error: dayOf parameter invalid
+        Error: startTime or stopTime parameters invalid
+
++ Response 404 (text/plain)
+
+        Error: vehicleId Not Found
 
 + Response 401
     + Body
@@ -1366,26 +1625,20 @@ ready then a `202` return code will be returned.
 
             Retry-After: {implementation-defined}
 
-## Vehicle-Only Telematics Export Format                           [/v1.0/export/vehiclerecords/status{?dayOf}]
-<a id="vehicle_only_telematics_export_format"></a>
-
-+ Parameters
-    + dayOf:    `2019-04-05T02:04:16Z` (required, string) - the day of interest, specified by any timestamp within that day, including 0000h
-
-+ Attributes (Vehicle Only Complete Telematics Records)
-
-### Test if Vehicle-Only Export Ready                          [GET]
-<a id="test_if_vehicle_only_export_ready"></a>
-
-If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
-ready then a `202` return code will be returned.
+## Get Vehicle Location History                                [GET /v1.0/vehicles/{vehicleId}/locations/{?startTime,stopTime}]
+<a id="get_vehicle_location_history"></a>
 
 **Access Controls**
 
 
 |Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
 |-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
+    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
+    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
 
 + Request
     + Headers
@@ -1393,16 +1646,15 @@ ready then a `202` return code will be returned.
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + location: `https://api.provider.com/v1.0/export/vehiclerecords/files/d8603741fd48a71cbf8546b04c9bc9f8` (required, string) - a URL where the complete file can be retrieved. If it is under that of the OTAPI endpoints then the same authentication and authorization schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible without any authentication or authorization and the client is expected to be configured with the appropriate credentials for download independently of responses from the OTAPI server.
-
-+ Response 202
-
-        File not yet ready for download
+    + Attributes (Vehicle Location Time History)
 
 + Response 400 (text/plain)
 
-        Error: dayOf parameter invalid
+        Error: startTime or stopTime parameters invalid
+
++ Response 404 (text/plain)
+
+        Error: vehicleId Not Found
 
 + Response 401
     + Body
@@ -1424,7 +1676,317 @@ ready then a `202` return code will be returned.
 
             Retry-After: {implementation-defined}
 
-# Group Use Case Driver Availability
+# Group Fleet
+
+## Follow Fleet Log Events                                     [GET /v1.0/event_logs/feed{?token}]
+<a id="follow_fleet_log_events"></a>
+
+Clients can follow a feed of Log Event entries as they are added to the TSP system; following is accomplished via
+polling an endpoint and providing a 'token' which evolves the window of new entries with each query in the polling.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | **DENY**   | ALLOW       | ALLOW         | **DENY**   |    ALLOW   | ALLOW      |
+
++ Parameters
+    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Log Events; pass in a `null` or omit this token to start with a new token set to 'now'.
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Log Events
+        + feed                                  (array[Log Event], fixed-type) - the 'feed' of Log Events
+
++ Response 400 (text/plain)
+
+        Error: token parameter invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Get Fleet Latest Locations                                  [GET /v1.0/fleet/locations/latest{?page,count}]
+<a id="get_fleet_latest_locations"></a>
+
+Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a given time period.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (Vehicle Location Time History)
+
++ Response 400 (text/plain)
+
+        Error: page or count parameters invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Get Fleet Location History                                  [GET /v1.0/fleet/locations/{?startTime,stopTime,page,count}]
+<a id="get_fleet_location_history"></a>
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
+    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
+    + page                             (optional, number) - the page to select for paginated response
+        + Default: 1
+    + count                            (optional, number) - the number of items to return
+        + Default: 50
+
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Headers
+
+            X-Total-Count: {+totalCount}
+
+    + Attributes (Vehicle Location Time History)
+
++ Response 400 (text/plain)
+
+        Error: startTime, stopTime, page or count parameters invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 413
+
+        Requested entity is too large
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Get Fleet Vehicle Info                                      [GET /v1.0/fleet/infos/{?startTime,stopTime}]
+<a id="get_fleet_vehicle_info"></a>
+
+Clients can retrieve a combination of all vehicle information for all vehicles over a given time period.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
+    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + coarseVehicleLocationTimeHistories                 (required, Coarse Vehicle Location Time History) - The Coarse Vehicle Location Time History for all vehicles in the requested time period
+        + flaggedVehicleFaultEvents                          (required, array[Flagged Vehicle Fault Code Event], fixed-type) - all Flagged Vehicle Fault Code Events for all vehicles in the requested time period
+        + vehiclePerformanceEvents                           (required, array[Vehicle Performance Event], fixed-type) - all vehicle performance events for all vehicles in the requested time period
+        + vehicleFaultCodeEvents                             (required, array[Vehicle Fault Code Event], fixed-type) - all vehicle fault code events for all vehicles in the requested time period
+
++ Response 400 (text/plain)
+
+        Error: startTime or stopTime parameters invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 413
+
+        Requested entity is too large
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Follow Fleet Vehicle Info                                   [GET /v1.0/fleet/infos/feed{?token}]
+<a id="follow_fleet_vehicle_info"></a>
+
+Clients can follow a feed of a combination of all vehicle information for all vehicles as they are added to the TSP
+system; following is accomplished via polling an endpoint and providing a 'token' which evolves the window of new
+entries with each query in the polling.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | ALLOW        | **DENY**   | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Log Events; pass in a `null` or omit this token to start with a new token set to 'now'.
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Log Events
+        + feed                                  (object) - the 'feed' of Fleet Vehicle Info
+            + coarseVehicleLocationTimeHistories                 (required, Coarse Vehicle Location Time History) - The Coarse Vehicle Location Time History for all vehicles in the requested time period
+            + flaggedVehicleFaultEvents                          (required, array[Flagged Vehicle Fault Code Event], fixed-type) - all Flagged Vehicle Fault Code Events for all vehicles in the requested time period
+            + vehiclePerformanceEvents                           (required, array[Vehicle Performance Event], fixed-type) - all vehicle performance events for all vehicles in the requested time period
+            + vehicleFaultCodeEvents                             (required, array[Vehicle Fault Code Event], fixed-type) - all vehicle fault code events for all vehicles in the requested time period
+
++ Response 400 (text/plain)
+
+        Error: token parameter invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 413
+
+        Requested entity is too large
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Follow Fleet Fault Code Events                              [GET /v1.0/fleet/faults/feed{?token}]
+<a id="follow_fleet_fault_code_events"></a>
+
+Clients can follow a feed of Vehicle Fault Code Events as they are added to the TSP system; following is accomplished
+bia polling an endpoint and providing a 'token' which evolves the window of new entries with each query in the polling.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | ALLOW        | **DENY**   | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Parameters
+    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Log Events; pass in a `null` or omit this token to start with a new token set to 'now'.
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Log Events
+        + feed                                  (array[Vehicle Fault Code Event], fixed-type) - the 'feed' of Log Events
+
++ Response 400 (text/plain)
+
+        Error: token parameters invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 413
+
+        Requested entity is too large
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+# Group Driver
 
 ## Get Driver Availability Factors                             [GET /v1.0/drivers/{driverId}/availability_factors/{?startTime,stopTime}]
 <a id="get_driver_availability_factors"></a>
@@ -1619,570 +2181,6 @@ Clients can send custom-integrated duty status changes to the TSP to trigger dut
 
             Retry-After: {implementation-defined}
 
-# Group Use Case Driver Route & Directions Communication
-
-## Update Driver Route Stop                                    [PUT /v1.0/vehicles/{vehicleId}/routes/{routeId}]
-<a id="update_driver_route_stop"></a>
-
-Clients can update a Driver's destination; sending data to this endpoint, using a previously obtained `routeId` will
-change the destination of the route, hence also changing the stopId associated with the route.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
-    + routeId           : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route created, to be used for later updates to the route
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-    + Attributes (Externally Sourced Route Stop Details)
-
-    + Schema
-
-            {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "title": "ExternallySourcedRouteStopDetails",
-                "required": [
-                  "stopName",
-                  "stopLocation"
-                ],
-                "type": "object",
-                "properties": {
-                  "stopName": {
-                    "type": "string",
-                    "description": "a name for the stop location",
-                    "example": "pickup place 101"
-                  },
-                  "stopAddress": {
-                    "type": "string",
-                    "description": "an optional street address",
-                    "example": "13 Sycamore Ave"
-                  },
-                  "stopLocation": {
-                    "type": "string",
-                    "description": "the location of the stop",
-                    "example": "37.4224764 -122.0842499"
-                  },
-                  "stopDeadline": {
-                    "type": "string",
-                    "description": "optional time and date when the stop must be arrived at",
-                    "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})[+-](\\d{2})\\:(\\d{2})$",
-                    "example": "2019-04-05T02:04:16Z"
-                  }
-                }
-              }
-
-+ Response 200 (application/json)
-
-    + Attributes (object)
-        + routeId       : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route updated, to be used for later updates to the route
-        + stopId        : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - the id of the stop in the updated route (most likely a re-used location), to be use for later updates to Stop Geograhic Details
-
-+ Response 204
-
-+ Response 404 (text/plain)
-
-        Error: vehicleId or routeId Not Found
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-## Update Stop Geographic Details                           [PATCH /v1.0/stops/{stopId}]
-<a id="update_stop_geographic_details"></a>
-
-Clients can update the _geographic details_ of a stop; the *Stop Geographic Details* are the specific location for the
-truck and trailer to park and a polygon of geographic points indicating the entryway onto a facility (i.e. where the
-truck should drive on approach).
-
-Sending data to this endpoint, using a previously returned `stopId` will update the geograhic details of the stop and
-any other routes using this stop will also be updated.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + stopId           : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - The stop id to update
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-    + Attributes (Externally Sourced Stop Geographic Details)
-
-    + Schema
-
-            {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "title": "ExternallySourcedStopGeographicDetails",
-                "required": [
-                  "location"
-                ],
-                "type": "object",
-                "properties": {
-                  "comment": {
-                    "type": "string",
-                    "description": "an optional comment"
-                  },
-                  "location": {
-                    "type": "string",
-                    "description": "the location of the delivery date at this stop",
-                    "example": "37.4224764 -122.0842499"
-                  },
-                  "entryArea": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "optional geographic location polygon detailing the entryway area for this stop"
-                  }
-                }
-            }
-
-+ Response 200 (application/json)
-
-    + Attributes (object)
-        + stopId        : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - the id of the stop that was updated, to be used for later updates to Stop Geograhic Details
-
-+ Response 204
-
-+ Response 404 (text/plain)
-
-        Error: stopId Not Found
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-# Group Use Case Driver Route & Directions Start
-
-## Get Vehicle Flagged Events                                  [GET /v1.0/vehicles/{vehicleId}/flagged_events/{?startTime,stopTime}]
-<a id="get_vehicle_flagged_events"></a>
-
-Clients can retrieve all the flagged vehicle events of a given vehicle over a given period of time.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
-    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
-    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (Vehicle Flagged Event)
-
-+ Response 400 (text/plain)
-
-        Error: startTime or stopTime parameters invalid
-
-+ Response 404 (text/plain)
-
-        Error: vehicleId Not Found
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 413
-
-        Requested entity is too large
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-## Create a Vehicle Route                                     [POST /v1.0/vehicles/{vehicleId}/routes]
-<a id="create_a_vehicle_route"></a>
-
-Clients can request the creation of a new route for a given vehicle, providing start & stop location along with
-additional instructions in a *Externally Sourced Route Start Stop Details* object.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-    + Attributes (Externally Sourced Route Start Stop Details)
-
-    + Schema
-
-            {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "title": "ExternallySourcedRouteStartStopDetails",
-                "required": [
-                  "startName",
-                  "startLocation",
-                  "stopName",
-                  "stopLocation"
-                ],
-                "type": "object",
-                "properties": {
-                  "startName": {
-                    "type": "string",
-                    "description": "a name for the start location",
-                    "example": "start place 202"
-                  },
-                  "startAddress": {
-                    "type": "string",
-                    "description": "an optional street address of the start",
-                    "example": "11 Elm Street"
-                  },
-                  "startLocation": {
-                    "type": "string",
-                    "description": "the location of the start",
-                    "example": "37.4224764 -122.0842499"
-                  },
-                  "routeAddInstructions": {
-                    "type": "string",
-                    "description": "an optional comment with details about the route",
-                    "example": "take trailers XXX and YYY"
-                  },
-                  "stopName": {
-                    "type": "string",
-                    "description": "a name for the stop location",
-                    "example": "pickup place 101"
-                  },
-                  "stopAddress": {
-                    "type": "string",
-                    "description": "an optional street address",
-                    "example": "13 Sycamore Ave"
-                  },
-                  "stopLocation": {
-                    "type": "string",
-                    "description": "the location of the stop",
-                    "example": "37.4224764 -122.0842499"
-                  },
-                  "stopDeadline": {
-                    "type": "string",
-                    "description": "optional time and date when the stop must be arrived at",
-                    "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2})\\:(\\d{2})\\:(\\d{2})[+-](\\d{2})\\:(\\d{2})$",
-                    "example": "2019-04-05T02:04:16Z"
-                  }
-                }
-            }
-
-+ Response 201 (application/json)
-
-    + Attributes (object)
-        + routeId       : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route created, to be used for later updates to the route
-        + stopId        : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - the id of the stop in the created route (most likely a re-used location), to be use for later updates to Stop Geograhic Details
-
-+ Response 204
-
-+ Response 404 (text/plain)
-
-        Error: vehicleId Not Found
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-# Group Use Case Driver Route and Directions Done
-
-## Follow Fleet Log Events                                     [GET /v1.0/event_logs/feed{?token}]
-<a id="follow_fleet_log_events"></a>
-
-Clients can follow a feed of Log Event entries as they are added to the TSP system; following is accomplished via
-polling an endpoint and providing a 'token' which evolves the window of new entries with each query in the polling.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | **DENY**   | ALLOW       | ALLOW         | **DENY**   |    ALLOW   | ALLOW      |
-
-+ Parameters
-    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Log Events; pass in a `null` or omit this token to start with a new token set to 'now'.
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Log Events
-        + feed                                  (array[Log Event], fixed-type) - the 'feed' of Log Events
-
-+ Response 400 (text/plain)
-
-        Error: token parameter invalid
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-# Group Use Case Driver Messaging by Geo-Location
-
-## Get Fleet Latest Locations                                  [GET /v1.0/fleet/locations/latest{?page,count}]
-<a id="get_fleet_latest_locations"></a>
-
-Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a given time period.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + page                             (optional, number) - the page to select for paginated response
-        + Default: 1
-    + count                            (optional, number) - the number of items to return
-        + Default: 50
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Headers
-
-            X-Total-Count: {+totalCount}
-
-    + Attributes (Vehicle Location Time History)
-
-+ Response 400 (text/plain)
-
-        Error: page or count parameters invalid
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-## Send Message to a Vehicle                                  [POST /v1.0/vehicles/{vehicleId}/message]
-<a id="send_message_to_a_vehicle"></a>
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to send the message to
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-    + Attributes (Externally Sourced Vehicle Display Messages)
-
-    + Schema
-
-            {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "title": "ExternallySourcedVehicleDisplayMessages",
-                "required": [
-                  "message"
-                ],
-                "type": "object",
-                "properties": {
-                  "subject": {
-                    "type": "string",
-                    "description": "a brief 'subject-line' for this message"
-                  },
-                  "message": {
-                    "type": "string",
-                    "description": "the message to be displayed to the driver"
-                  }
-                }
-            }
-
-+ Response 201 (application/json)
-    + Attributes (object)
-        + messageReceiptId:   `FC5E038D38A57032085441E7FE7010B0` (required, string) - the id of the Message Receipt object that will track the delivery- and option display-timestamps of this message
-
-+ Response 204
-
-+ Response 404 (text/plain)
-
-        Error: vehicleId not found
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-
-# Group Use Case Driver Messaging by Vehicle
-
-# Group Use Case Vehicle Location Time History Processing
-
-## Get Fleet Location History                                  [GET /v1.0/fleet/locations/{?startTime,stopTime,page,count}]
-<a id="get_fleet_location_history"></a>
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
-    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
-    + page                             (optional, number) - the page to select for paginated response
-        + Default: 1
-    + count                            (optional, number) - the number of items to return
-        + Default: 50
-
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Headers
-
-            X-Total-Count: {+totalCount}
-
-    + Attributes (Vehicle Location Time History)
-
-+ Response 400 (text/plain)
-
-        Error: startTime, stopTime, page or count parameters invalid
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 413
-
-        Requested entity is too large
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-# Group Use Case Human Resources Process: Payroll
-
 ## Update Driver Info                                        [PATCH /v1.0/drivers/{driverId}]
 <a id="update_driver_info"></a>
 
@@ -2268,119 +2266,6 @@ Clients can request updates to the TSP's managed user accounts for drivers by se
     + Headers
 
             Retry-After: {implementation-defined}
-
-# Group Use Case Human Resources Process: Accident Report
-
-# Group Use Case Carrier Custom Business Intelligence
-
-## Get Fleet Vehicle Info                                      [GET /v1.0/fleet/infos/{?startTime,stopTime}]
-<a id="get_fleet_vehicle_info"></a>
-
-Clients can retrieve a combination of all vehicle information for all vehicles over a given time period.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
-    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + coarseVehicleLocationTimeHistories                 (required, Coarse Vehicle Location Time History) - The Coarse Vehicle Location Time History for all vehicles in the requested time period
-        + flaggedVehicleFaultEvents                          (required, array[Flagged Vehicle Fault Code Event], fixed-type) - all Flagged Vehicle Fault Code Events for all vehicles in the requested time period
-        + vehiclePerformanceEvents                           (required, array[Vehicle Performance Event], fixed-type) - all vehicle performance events for all vehicles in the requested time period
-        + vehicleFaultCodeEvents                             (required, array[Vehicle Fault Code Event], fixed-type) - all vehicle fault code events for all vehicles in the requested time period
-
-+ Response 400 (text/plain)
-
-        Error: startTime or stopTime parameters invalid
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 413
-
-        Requested entity is too large
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-## Follow Fleet Vehicle Info                                   [GET /v1.0/fleet/infos/feed{?token}]
-<a id="follow_fleet_vehicle_info"></a>
-
-Clients can follow a feed of a combination of all vehicle information for all vehicles as they are added to the TSP
-system; following is accomplished via polling an endpoint and providing a 'token' which evolves the window of new
-entries with each query in the polling.
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | ALLOW        | **DENY**   | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Log Events; pass in a `null` or omit this token to start with a new token set to 'now'.
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Log Events
-        + feed                                  (object) - the 'feed' of Fleet Vehicle Info
-            + coarseVehicleLocationTimeHistories                 (required, Coarse Vehicle Location Time History) - The Coarse Vehicle Location Time History for all vehicles in the requested time period
-            + flaggedVehicleFaultEvents                          (required, array[Flagged Vehicle Fault Code Event], fixed-type) - all Flagged Vehicle Fault Code Events for all vehicles in the requested time period
-            + vehiclePerformanceEvents                           (required, array[Vehicle Performance Event], fixed-type) - all vehicle performance events for all vehicles in the requested time period
-            + vehicleFaultCodeEvents                             (required, array[Vehicle Fault Code Event], fixed-type) - all vehicle fault code events for all vehicles in the requested time period
-
-+ Response 400 (text/plain)
-
-        Error: token parameter invalid
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 413
-
-        Requested entity is too large
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-# Group Use Case Compliance and Safety Monitoring
 
 ## Get Driver Performance Summaries                            [GET /v1.0/drivers/{driverId}/performance_summaries/{?startTime,stopTime}]
 <a id="get_driver_performance_summaries"></a>
@@ -2506,23 +2391,22 @@ Clients can request updates to the TSP's portal user accounts for drivers by sen
 
             Retry-After: {implementation-defined}
 
-# Group Use Case In-Field Maintenance & Repair
+# Group State of Health
 
-## Follow Fleet Fault Code Events                              [GET /v1.0/fleet/faults/feed{?token}]
-<a id="follow_fleet_fault_code_events"></a>
+## Check Current State of Health                               [GET /v1.0/health/current]
+<a id="check_current_state_of_health"></a>
 
-Clients can follow a feed of Vehicle Fault Code Events as they are added to the TSP system; following is accomplished
-bia polling an endpoint and providing a 'token' which evolves the window of new entries with each query in the polling.
+Clients can request the current service state of health. The response to this query will be a data structure indicating
+everything is good or showing some details as to why the service is not presently at 100%.
+
+Clients must treat any response other than code 200, code 401, or code 429 as equivalent to `SERVICESTATUS_MAJOR_OUTAGE`.
 
 **Access Controls**
 
 
 |Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
 |-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | ALLOW        | **DENY**   | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + token: `37A6259CC0C1DAE299A7866489DFF0BD` (string, optional) - a since-token, pass-in the token previously returned to 'follow' new Log Events; pass in a `null` or omit this token to start with a new token set to 'now'.
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | ALLOW      | ALLOW      | ALLOW      |
 
 + Request
     + Headers
@@ -2530,13 +2414,7 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + token                                 (string) - a since-token, pass-in the token previously returned by GET of `feed` to 'follow' new Log Events
-        + feed                                  (array[Vehicle Fault Code Event], fixed-type) - the 'feed' of Log Events
-
-+ Response 400 (text/plain)
-
-        Error: token parameters invalid
+    + Attributes (State of Health)
 
 + Response 401
     + Body
@@ -2545,10 +2423,6 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
-
-+ Response 413
-
-        Requested entity is too large
 
 + Response 429
     + Body
@@ -2558,20 +2432,21 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
 
             Retry-After: {implementation-defined}
 
-## Get Vehicle Location History                                [GET /v1.0/vehicles/{vehicleId}/locations/{?startTime,stopTime}]
-<a id="get_vehicle_location_history"></a>
+## Check Past 30d State of Health                              [GET /v1.0/health/recents]
+<a id="check_past_30d_state_of_health"></a>
+
+Clients can request the recent history of all service statuses. The response to this query will return all service
+status records (i.e. those returned via [Check Current State of Health](#check_current_state_of_health)) from over th
+past 30 days.
+
+Clients must treat any response other than code 200, code 401, or code 429 as equivalent to `SERVICESTATUS_MAJOR_OUTAGE`.
 
 **Access Controls**
 
 
 |Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
 |-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
-    + startTime:`2019-04-05T02:04:16Z` (required, string) - the start-date of the search
-    + stopTime: `2019-04-05T02:04:16Z` (required, string) - the stop-date of the search
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | ALLOW      | ALLOW      | ALLOW      |
 
 + Request
     + Headers
@@ -2579,15 +2454,8 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (Vehicle Location Time History)
-
-+ Response 400 (text/plain)
-
-        Error: startTime or stopTime parameters invalid
-
-+ Response 404 (text/plain)
-
-        Error: vehicleId Not Found
+    + Attributes (object)
+        + data (array[State of Health], fixed-type)
 
 + Response 401
     + Body
@@ -2596,10 +2464,6 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
-
-+ Response 413
-
-        Requested entity is too large
 
 + Response 429
     + Body
@@ -3009,6 +2873,124 @@ the request headers.)
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+# Group Data Export
+
+## Complete Telematics Export Format                               [/v1.0/export/allrecords/status{?dayOf}]
+<a id="complete_telematics_export_format"></a>
+
++ Parameters
+    + dayOf:    `2019-04-05T02:04:16Z` (required, string) - the day of interest, specified by any timestamp within that day, including 0000h
+
++ Attributes (Complete Telematics Records)
+
+### Test if Complete Export Ready                              [GET]
+<a id="test_if_complete_export_ready"></a>
+
+If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
+ready then a `202` return code will be returned.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| **DENY**    | **DENY**     | ALLOW      | **DENY**    | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + location: `https://api.provider.com/v1.0/export/allrecords/files/d8603741fd48a71cbf8546b04c9bc9f8` (required, string) - a URL where the complete file can be retrieved. If it is under that of the OTAPI endpoints then the same authentication and authorization schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible without any authentication or authorization and the client is expected to be configured with the appropriate credentials for download independently of responses from the OTAPI server.
+
++ Response 202
+
+        File not yet ready for download
+
++ Response 400 (text/plain)
+
+        Error: dayOf parameter invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 413
+
+        Requested entity is too large
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## Vehicle-Only Telematics Export Format                           [/v1.0/export/vehiclerecords/status{?dayOf}]
+<a id="vehicle_only_telematics_export_format"></a>
+
++ Parameters
+    + dayOf:    `2019-04-05T02:04:16Z` (required, string) - the day of interest, specified by any timestamp within that day, including 0000h
+
++ Attributes (Vehicle Only Complete Telematics Records)
+
+### Test if Vehicle-Only Export Ready                          [GET]
+<a id="test_if_vehicle_only_export_ready"></a>
+
+If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
+ready then a `202` return code will be returned.
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + location: `https://api.provider.com/v1.0/export/vehiclerecords/files/d8603741fd48a71cbf8546b04c9bc9f8` (required, string) - a URL where the complete file can be retrieved. If it is under that of the OTAPI endpoints then the same authentication and authorization schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible without any authentication or authorization and the client is expected to be configured with the appropriate credentials for download independently of responses from the OTAPI server.
+
++ Response 202
+
+        File not yet ready for download
+
++ Response 400 (text/plain)
+
+        Error: dayOf parameter invalid
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 413
+
+        Requested entity is too large
 
 + Response 429
     + Body

--- a/apiary.apib
+++ b/apiary.apib
@@ -6,15 +6,23 @@ A project to enable business resiliency for motor freight carriers with tight in
 
 ![NMFTA Logo](https://raw.githubusercontent.com/nmfta-repo/nmfta-opentelematics-api/master/media/image1.png)
 
-This document is written using [api-blueprint](https://apiblueprint.org/) and available online at both
-[opentelematicsapi.docs.apiary.io](https://opentelematicsapi.docs.apiary.io/#) (for browsable document) and
-https://github.com/nmfta-repo/nmfta-opentelematics-api for the API blueprint source. Please use https://github.com/nmfta-repo/nmfta-opentelematics-api to raise issues and suggest changes to the API.
+This document is written in [API Blueprint format 1A](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md).
 
-If a telematics system provider (TSP) suddenly goes out of business
-(have had two examples of this in 2018) any commercial fleet relying on
-their service will need to find a new provider. Due to the lack of a
-standardized telematics data format, a commercial fleet manager will
-have to reintegrate an alternate telematics provider's data format into
+The draft specification is pubished in various forms:
+
+* at [github.com/nmfta-repo/nmfta-opentelematics-api](https://github.com/nmfta-repo/nmfta-opentelematics-api)
+* here, [opentelematicsapi.docs.apiary.io](https://opentelematicsapi.docs.apiary.io), as:
+    * Interactive documentation
+    * A mock server
+* at [apimatic/.../nmfta-opentelematics-api](https://www.apimatic.io/apidocs/nmfta-opentelematics-api) as:
+    * Exportable API specifications in multiple formats including: Open API 3.0, RAML 1.0, and Swagger 2.0
+    * Downloadable (client) SDKs in .NET and Python
+
+# Motivation
+
+If a telematics system provider (TSP) suddenly goes out of business (have had two examples of this in 2018) any
+commercial fleet relying on their service will need to find a new provider. Due to the lack of a standardized telematics
+data format, a commercial fleet manager will have to reintegrate an alternate telematics provider's data format into
 their existing system reporting.
 
 The Open Telematics API (OTAPI) is intended to make the TSP-Carrier interface the same across multiple TSPs. It is not

--- a/apiary.apib
+++ b/apiary.apib
@@ -61,13 +61,13 @@ Authorization: Basic YWRtaW46YWRtaW4=
 ```
 
 This authentication method relies entirely on the security protections provided by the TLS layer; therefore HTTPS is
-mandatory on all connections and implementors must follow adhere to the security requirements detailed in the *Security
-Requirements for Implementors* section below.
+mandatory on all connections and implementors must follow adhere to the security requirements detailed in the [Security Requirements for Implementors](#security_requirements_for_implementors) section below.
 
 TSPs implementing the Open Telematics API must provide a means to create username-password pair credentials and these
-must be associated with roles (see section *Authorization* below).
+must be associated with roles (see section [Authorization](#authorization) below).
 
 # Authorization
+<a id="authorization"></a>
 
 TSPs implementing the Open Telematics API must include access controls for requests against the following roles.
 
@@ -107,6 +107,7 @@ are assigned `DENY/ALLOW` such that:
 * the *HR* role is allowed to update Driver information and TSP portal user accounts
 
 # Security Requirements for Implementors
+<a id="security_requirements_for_implementors"></a>
 
 All TSPs that implement an Open Telematics API instance are expected to
 provide a secure service by default. In what follows we outline some
@@ -303,6 +304,7 @@ there needs to be a concept of an 'unknown driver'. Indeed this concept is part 
 API objects: `driverID` references to the unknown driver is represented by `null`.
 
 # Provider Identifiers
+<a id="provider_identifiers"></a>
 
 An important use case of the Open Telematics API by motor freight carriers is to run 'mixed fleets' where there are more
 than one TSP's service integrated concurrently. In such a seployment we can imagine possible issues with duplicated data
@@ -333,7 +335,8 @@ specification.
 
 Addition of fields to the objects must be done such that it is not possible for the new extension fields to collide with
 other extensions or with future versions of the API; therefore, all fields added as extensions must be prefixed with
-`x_providerid_` where `providerid` is the provider ID (see *Provider Identifiers* above for more details).
+`x_providerid_` where `providerid` is the provider ID (see [Provider Identifiers](#provider_identifiers) above for more
+details).
 
 * Adding addional field/members to the data objects, when the data is needed by a motor freight carrier IS a valid extension to the OTAPI
 * Adding additional possible values to enumerations IS NOT a valid extension to the OTAPI
@@ -959,6 +962,7 @@ issues with its services at the moment of query or some details describing the c
 less than optimal operation.
 
 ## Check Current State of Health                               [GET /v1.0/health/current]
+<a id="check_current_state_of_health"></a>
 
 Clients can request the current service state of health. The response to this query will be a data structure indicating
 everything is good or showing some details as to why the service is not presently at 100%.
@@ -997,6 +1001,7 @@ Clients must treat any response other than code 200, code 401, or code 429 as eq
             Retry-After: {implementation-defined}
 
 ## Check Past 30d State of Health                              [GET /v1.0/health/recents]
+<a id="check_past_30d_state_of_health"></a>
 
 Clients can request the recent history of all service statuses. The response to this query will return all service
 status records (i.e. those returned via *Check Current State of Health*) from over the past 30 days.
@@ -1088,8 +1093,7 @@ the daily export files.
 
 ***Complete Data Export***
 
-The *Complete Data Export* objects will contain all of the following object embedded, see *Complete Telematics Records
-Daily Export Format* below for more details.
+The *Complete Data Export* objects will contain all of the following object embedded, see [Complete Telematics Export Format](#complete_telematics_export_format) below for more details.
 
 * Vehicle
 * Vehicle Location Time History
@@ -1106,8 +1110,7 @@ Daily Export Format* below for more details.
 
 ***Vehicle-Only Data Export***
 
-The *Vehicle Only Complete Telematics Records* objects will contain only the following embedded objects, see *Vehicle-
-Only Complete Telematics Records Daily Export Format* for more details.
+The *Vehicle Only Complete Telematics Records* objects will contain only the following embedded objects, see [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) for more details.
 
 * Stop Geographic Details
 * Vehicle
@@ -1118,6 +1121,7 @@ Only Complete Telematics Records Daily Export Format* for more details.
 * State of Health
 
 ## Complete Telematics Export Format                               [/v1.0/export/allrecords/status{?dayOf}]
+<a id="complete_telematics_export_format"></a>
 
 + Parameters
     + dayOf:    `2019-04-05T02:04:16Z` (required, string) - the day of interest, specified by any timestamp within that day, including 0000h
@@ -1125,6 +1129,7 @@ Only Complete Telematics Records Daily Export Format* for more details.
 + Attributes (Complete Telematics Records)
 
 ### Test if Complete Export Ready                              [GET]
+<a id="test_if_complete_export_ready"></a>
 
 If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
 ready then a `202` return code will be returned.
@@ -1174,6 +1179,7 @@ ready then a `202` return code will be returned.
             Retry-After: {implementation-defined}
 
 ## Vehicle-Only Telematics Export Format                           [/v1.0/export/vehiclerecords/status{?dayOf}]
+<a id="vehicle_only_telematics_export_format"></a>
 
 + Parameters
     + dayOf:    `2019-04-05T02:04:16Z` (required, string) - the day of interest, specified by any timestamp within that day, including 0000h
@@ -1181,6 +1187,7 @@ ready then a `202` return code will be returned.
 + Attributes (Vehicle Only Complete Telematics Records)
 
 ### Test if Vehicle-Only Export Ready                          [GET]
+<a id="test_if_vehicle_only_export_ready"></a>
 
 If the file is ready the response will include a URL where the complete file can be fetched; if the file is not yet
 ready then a `202` return code will be returned.
@@ -1245,8 +1252,8 @@ kinds of nuances that are handled by TPSs in their service offering and OTAPI is
 Personnel responsible for compliance need to be able to create RODS based on information exported from OTAPI in the
 event a TSP is no longer available.
 
-See *Complete Telematics Records Daily Export Format* above for more details on the file format which should contain
-sufficient data for this use case in the array of *Log Event* objects.
+See [Complete Telematics Export Format](#complete_telematics_export_format) above for more details on the file format
+which should contain sufficient data for this use case in the array of *Log Event* objects.
 
 # Group Use Case Driver Availability
 
@@ -1273,6 +1280,7 @@ this their systems send data _to_ the TSPs.
 * Externally Triggered Duty Status Change
 
 ## Get Driver Availability Factors                             [GET /v1.0/drivers/{driverId}/availability_factors/{?startTime,stopTime}]
+<a id="get_driver_availability_factors"></a>
 
 Clients can request all the factors contributing to driver availability for a given driver, over a given time period.
 
@@ -1328,6 +1336,7 @@ Clients can request all the factors contributing to driver availability for a gi
             Retry-After: {implementation-defined}
 
 ## Get Driver Breaks and Waivers                               [GET /v1.0/drivers/{driverId}/breaks_and_waivers/{?startTime,stopTime}]
+<a id="get_driver_breaks_and_waivers"></a>
 
 Clients can request any region-specific waivers and break-rules for a given driver that are applicable within a given
 time period.
@@ -1383,6 +1392,7 @@ time period.
             Retry-After: {implementation-defined}
 
 ## Update Driver Duty Status                                 [PATCH /v1.0/drivers/{driverId}/duty_status]
+<a id="update_driver_duty_status"></a>
 
 Clients can send custom-integrated duty status changes to the TSP to trigger duty status changes for a given driver by pushing data to this endpoint.
 
@@ -1472,7 +1482,8 @@ This feature is heavily used but also is commonly offered as an add-on to the TS
 
 Both personnel and semi-automated systems responsible for planning and assigning driver routes want to update the
 Driver's destination and route during a trip. They retrieve the driver availability factors for the time period from the
-driver's start of route up until the present (see *Retrieve Driver Availability Factors* above for more details.)
+driver's start of route up until the present (see [Get Driver Availability Factors](#get_driver_availability_factors)
+above for more details.)
 
 In the process of updating the Driver's destination and route, the motor freight carrier sends the following _to_ the
 TSP
@@ -1481,6 +1492,7 @@ TSP
 * Stop Details
 
 ## Update Driver Route Stop                                    [PUT /v1.0/vehicles/{vehicleId}/routes/{routeId}]
+<a id="update_driver_route_stop"></a>
 
 Clients can update a Driver's destination; sending data to this endpoint, using a previously obtained `routeId` will
 change the destination of the route, hence also changing the stopId associated with the route.
@@ -1569,6 +1581,7 @@ change the destination of the route, hence also changing the stopId associated w
 ## Route Stop Geographic Details                                   [/v1.0/stops/{stopId}]
 
 ### Get Stop Geographic Details                                [GET]
+<a id="get_stop_geographic_details"></a>
 
 Clients can retrieve the _geographic details_ of a stop; the *Stop Geographic Details* are the specific location for the
 truck and trailer to park and a polygon of geographic points indicating the entryway onto a facility (i.e. where the
@@ -1616,6 +1629,7 @@ truck should drive on approach).
             Retry-After: {implementation-defined}
 
 ### Update Stop Geographic Details                           [PATCH]
+<a id="update_stop_geographic_details"></a>
 
 Clients can update the _geographic details_ of a stop; the *Stop Geographic Details* are the specific location for the
 truck and trailer to park and a polygon of geographic points indicating the entryway onto a facility (i.e. where the
@@ -1717,6 +1731,7 @@ modifications to the route.
 * Externally Sourced Route Start Stop Details
 
 ## Get Vehicle Flagged Events                                  [GET /v1.0/vehicles/{vehicleId}/flagged_events/{?startTime,stopTime}]
+<a id="get_vehicle_flagged_events"></a>
 
 Clients can retrieve all the flagged vehicle events of a given vehicle over a given period of time.
 
@@ -1769,6 +1784,7 @@ Clients can retrieve all the flagged vehicle events of a given vehicle over a gi
             Retry-After: {implementation-defined}
 
 ## Create a Vehicle Route                                     [POST /v1.0/vehicles/{vehicleId}/routes]
+<a id="create_a_vehicle_route"></a>
 
 Clients can request the creation of a new route for a given vehicle, providing start & stop location along with
 additional instructions in a *Externally Sourced Route Start Stop Details* object.
@@ -1890,10 +1906,10 @@ And mark trips completed based on the Log Event context; at the end of a trip th
 
 * Stop Geographic Details
 
-to receive updates on changes to gates, access, repairs etc at the destination (see *Retrieve Route Stop Geographic
-Details* above for more details.)
+to receive updates on changes to gates, access, repairs etc at the destination (see [Get Stop Geographic Details](#get_stop_geographic_details) above for more details.)
 
 ## Follow Fleet Log Events                                     [GET /v1.0/event_logs/feed{?token}]
+<a id="follow_fleet_log_events"></a>
 
 Clients can follow a feed of Log Event entries as they are added to the TSP system; following is accomplished via
 polling an endpoint and providing a 'token' which evolves the window of new entries with each query in the polling.
@@ -1954,6 +1970,7 @@ vehicle by sending data _to_ the TSP:
 * Externally Sourced Vehicle Display Messages
 
 ## Get Fleet Latest Locations                                  [GET /v1.0/fleet/locations/latest{?page,count}]
+<a id="get_fleet_latest_locations"></a>
 
 Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a given time period.
 
@@ -2003,6 +2020,7 @@ Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a giv
             Retry-After: {implementation-defined}
 
 ## Send Message to a Vehicle                                  [POST /v1.0/vehicles/{vehicleId}/message]
+<a id="send_message_to_a_vehicle"></a>
 
 **Access Controls**
 
@@ -2077,7 +2095,7 @@ data _to_ the TSP for a given vehicle:
 
 * Externally Sourced Vehicle Display Messages
 
-(see *Send a Vehicle Display Message to a Vehicle* above for more details.)
+(see [Send Message to a Vehicle](#send_message_to_a_vehicle) above for more details.)
 
 # Group Use Case Vehicle Location Time History Tracking
 
@@ -2092,6 +2110,7 @@ period. They query the API for
 of all vehicles over a given time period.
 
 ## Get Fleet Location History                                  [GET /v1.0/fleet/locations/{?startTime,stopTime,page,count}]
+<a id="get_fleet_location_history"></a>
 
 **Access Controls**
 
@@ -2155,26 +2174,27 @@ this they follow a feed of:
 
 * Log Event
 
-(see *Follow a Feed of Log Events* above for more details) and they query for breaks and exemption rules for
-(drivers in those logs:
+(see [Follow Fleet Log Events](#follow_fleet_log_events) above for more details) and they query for breaks and exemption
+rules for drivers in those logs:
 
 * Region Specific Break Rules
 * Region Specific Waivers
 
-(see *Check Break Rules and Waivers* above for more details.)
+(see [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) above for more details.)
 
 In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
 this their systems send data _to_ the TSPs:
 
 * Externally Triggered Duty Status Change
 
-(see *Send Custom-Integrated Duty Status Changes to the TSP* above for more details.) HR staff want to associate their
-(Driver's with metadata for use by the TSP. e.g. the region of governance for duty breaks and exemptions. To do this
-(their systems send data _to_ the TSPs:
+(see [Update Driver Duty Status](#update_driver_duty_status) above for more details.) HR staff want to associate their
+Driver's with metadata for use by the TSP. e.g. the region of governance for duty breaks and exemptions. To do this
+their systems send data _to_ the TSPs:
 
 * Externally Sourced Driver Info
 
 ## Update Driver Info                                        [PATCH /v1.0/drivers/{driverId}]
+<a id="update_driver_info"></a>
 
 Clients can request updates to the TSP's managed user accounts for drivers by sending data to this endpoint.
 
@@ -2268,7 +2288,7 @@ internally according to their own processes. To do this they follow a feed of:
 
 * Log Event
 
-(see *Follow a Feed of Log Events* above for more details.)
+(see [Follow Fleed Log Events](#follow_fleet_log_events) above for more details.)
 
 # Group Use Case Carrier Custom Business Intelligence
 
@@ -2285,15 +2305,16 @@ time period. They query the API for
 
 of all vehicles over a given time period.
 
-For certain use cases, they may opt to *follow* a feed of the above objects instead. See *Follow Fleet Vehicle Info* below.
+For certain use cases, they may opt to *follow* a feed of the above objects instead. See [Follow Fleet Vehicle Info](#follow_fleet_vehicle_info) below.
 
 They may also follow-up with queries of the hi-resolution time history of the fleet for a given time period:
 
 * Vehicle Location Time History
 
-(see *Retrieve All Vehicle Location Time Histories* above for more details.)
+(see [Get Fleet Location History](#get_fleet_location_history) above for more details.)
 
 ## Get Fleet Vehicle Info                                      [GET /v1.0/fleet/infos/{?startTime,stopTime}]
+<a id="get_fleet_vehicle_info"></a>
 
 Clients can retrieve a combination of all vehicle information for all vehicles over a given time period.
 
@@ -2345,6 +2366,7 @@ Clients can retrieve a combination of all vehicle information for all vehicles o
             Retry-After: {implementation-defined}
 
 ## Follow Fleet Vehicle Info                                   [GET /v1.0/fleet/infos/feed{?token}]
+<a id="follow_fleet_vehicle_info"></a>
 
 Clients can follow a feed of a combination of all vehicle information for all vehicles as they are added to the TSP
 system; following is accomplished via polling an endpoint and providing a 'token' which evolves the window of new
@@ -2413,6 +2435,7 @@ field. They send data _to_ the TSP:
 * External TSP Portal User Management
 
 ## Get Driver Performance Summaries                            [GET /v1.0/drivers/{driverId}/performance_summaries/{?startTime,stopTime}]
+<a id="get_driver_performance_summaries"></a>
 
 Clients can request all driver performance summaries for a specific driver within a given period of time.
 
@@ -2466,6 +2489,7 @@ Clients can request all driver performance summaries for a specific driver withi
             Retry-After: {implementation-defined}
 
 ## Update Driver TSP Portal Account                          [PATCH /v1.0/drivers/{driverId}/driverportaluser]
+<a id="update_driver_tsp_portal_account"></a>
 
 Clients can request updates to the TSP's portal user accounts for drivers by sending data to this endpoint.
 
@@ -2549,6 +2573,7 @@ recent vehicle location
 * Vehicle Location Time History
 
 ## Follow Fleet Fault Code Events                              [GET /v1.0/fleet/faults/feed{?token}]
+<a id="follow_fleet_fault_code_events"></a>
 
 Clients can follow a feed of Vehicle Fault Code Events as they are added to the TSP system; following is accomplished
 bia polling an endpoint and providing a 'token' which evolves the window of new entries with each query in the polling.
@@ -2598,6 +2623,7 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
             Retry-After: {implementation-defined}
 
 ## Get Vehicle Location History                                [GET /v1.0/vehicles/{vehicleId}/locations/{?startTime,stopTime}]
+<a id="get_vehicle_location_history"></a>
 
 **Access Controls**
 
@@ -2659,6 +2685,7 @@ in API Blueprint's formal spec language.
     + data (array[Token Translation], fixed-type)
 
 ### Get a Translation Table                                    [GET]
+<a id="get_a_translation_table"></a>
 
 Clients can retrieve the current translation table for this TSP's Open Telematics API for given language (provided in
 the request headers.)
@@ -3065,6 +3092,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 + Attributes (Log Event)
 
 ### Get a Log Event by its ID                                  [GET]
+<a id="get_a_log_event_by_its_ID"></a>
 
 **Access Controls**
 
@@ -3105,6 +3133,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 + Attributes (Driver)
 
 ### Get a Driver Object by its ID                              [GET]
+<a id="get_a_driver_object_by_its_id"></a>
 
 **Access Controls**
 
@@ -3146,6 +3175,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 
 
 ### Get a Vehicle Object by its ID                             [GET]
+<a id="get_a_vehicle_object_by_its_id"></a>
 
 **Access Controls**
 
@@ -3187,6 +3217,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 
 
 ### Get a Message Receipt by its ID                            [GET]
+<a id="get_a_message_receipt_by_its_id"></a>
 
 **Access Controls**
 
@@ -3232,6 +3263,7 @@ rules.
 + Attributes (Region Specific Break Rules)
 
 ### Get a Region Specific Break Rules by its ID                [GET]
+<a id="get_a_region_specific_break_rules_by_its_id"></a>
 
 **Access Controls**
 
@@ -3275,6 +3307,7 @@ available
 + Attributes (Region Specific Waivers)
 
 ### Get a Region Specific Waivers by its ID                    [GET]
+<a id="get_a_region_specific_waivers_by_its_id"></a>
 
 **Access Controls**
 
@@ -3315,6 +3348,7 @@ available
 + Attributes (Stop Geographic Details)
 
 ### Get a Stop Geographic Details by its ID                    [GET]
+<a id="get_a_stop_geographic_details_by_its_id"></a>
 
 **Access Controls**
 
@@ -3355,6 +3389,7 @@ available
 + Attributes (Vehicle Location Time)
 
 ### Get a Vehicle Location Time by its ID                      [GET]
+<a id="get_a_vehicle_location_time_by_its_id"></a>
 
 **Access Controls**
 
@@ -3397,6 +3432,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 + Attributes (Vehicle Flagged Event)
 
 ### Get a Vehicle Flagged Event by its ID                      [GET]
+<a id="get_a_vehicle_flagged_event_by_its_id"></a>
 
 **Access Controls**
 
@@ -3437,6 +3473,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 + Attributes (Vehicle Fault Code Event)
 
 ### Get a Vehicle Fault Code Event by its ID                   [GET]
+<a id="get_a_vehicle_fault_code_event_by_its_id"></a>
 
 **Access Controls**
 
@@ -3477,6 +3514,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 + Attributes (Flagged Vehicle Fault Code Event)
 
 ### Get a Flagged Vehicle Fault Code Event by its ID           [GET]
+<a id="get_a_flagged_vehicle_fault_code_event_by_its_id"></a>
 
 **Access Controls**
 
@@ -3517,6 +3555,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 + Attributes (Vehicle Performance Event)
 
 ### Get a Vehicle Performance Event by its ID                  [GET]
+<a id="get_a_vehicle_performance_event_by_its_id"></a>
 
 **Access Controls**
 
@@ -3559,6 +3598,7 @@ Summary statistics on performance of drivers.
 + Attributes (Driver Performance Summary)
 
 ### Get a Driver Performance Summary by its ID                 [GET]
+<a id="get_a_driver_performance_summary_by_its_id"></a>
 
 **Access Controls**
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -375,8 +375,10 @@ provided below for convenience in the sample response to `GET /v1.0/i18n`.
 The Open Telematics API is envisioned to be complete enough that motor freight carriers can use these APIs instead of
 the proprietary TSP APIs -- while still connecting-to TSP-hosted servers and hence still using the same provider. In the
 interest of ensuring that the APIs are _useful_ to their intended users (motor freight carriers) we will capture -- and
-organize -- the API by these use cases. See the sections below for the API endpoints in those categories. For ease of
-reference, we summarize the use cases here:
+organize -- the API by these use cases. Each use case description in the following subsections includes links to the
+API endpoints upon which the use case relies. The links can be followed to the *Reference* section for details on the
+endpoint. It is the intention of the authors that each endpoint is defined to satisfy a use case and no endpoint
+is introduced without a supporting use case captured here.
 
 ## Check Provider's State of Health
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -981,11 +981,17 @@ Clients must treat any response other than code 200, code 401, or code 429 as eq
     + Attributes (State of Health)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1014,11 +1020,17 @@ Clients must treat any response other than code 200, code 401, or code 429 as eq
         + data (array[State of Health], fixed-type)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1135,18 +1147,28 @@ ready then a `202` return code will be returned.
 
 + Response 202
 
+        File not yet ready for download
+
 + Response 400 (text/plain)
 
         Error: dayOf parameter invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1181,18 +1203,28 @@ ready then a `202` return code will be returned.
 
 + Response 202
 
+        File not yet ready for download
+
 + Response 400 (text/plain)
 
         Error: dayOf parameter invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1276,13 +1308,21 @@ Clients can request all the factors contributing to driver availability for a gi
         Error: driverId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1323,13 +1363,21 @@ time period.
         Error: driverId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1399,11 +1447,17 @@ Clients can send custom-integrated duty status changes to the TSP to trigger dut
         Error: driverId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1497,11 +1551,17 @@ change the destination of the route, hence also changing the stopId associated w
         Error: vehicleId or routeId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1540,11 +1600,17 @@ truck should drive on approach).
         Error: stopId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1616,11 +1682,17 @@ any other routes using this stop will also be updated.
         Error: stopId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1677,13 +1749,21 @@ Clients can retrieve all the flagged vehicle events of a given vehicle over a gi
         Error: vehicleId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1780,11 +1860,17 @@ additional instructions in a *Externally Sourced Route Start Stop Details* objec
         Error: vehicleId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1837,11 +1923,17 @@ polling an endpoint and providing a 'token' which evolves the window of new entr
         Error: token parameter invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1895,11 +1987,17 @@ Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a giv
         Error: page or count parameters invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -1955,11 +2053,17 @@ Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a giv
         Error: vehicleId not found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2022,13 +2126,21 @@ of all vehicles over a given time period.
         Error: startTime, stopTime, page or count parameters invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2132,11 +2244,17 @@ Clients can request updates to the TSP's managed user accounts for drivers by se
         Error: driverId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2207,13 +2325,21 @@ Clients can retrieve a combination of all vehicle information for all vehicles o
         Error: startTime or stopTime parameters invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2253,13 +2379,21 @@ entries with each query in the polling.
         Error: token parameter invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2312,13 +2446,21 @@ Clients can request all driver performance summaries for a specific driver withi
         Error: driverId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2377,11 +2519,17 @@ Clients can request updates to the TSP's portal user accounts for drivers by sen
         Error: driverId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2430,13 +2578,21 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
         Error: token parameters invalid
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2472,13 +2628,21 @@ bia polling an endpoint and providing a 'token' which evolves the window of new 
         Error: vehicleId Not Found
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 413
 
+        Requested entity is too large
+
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2496,7 +2660,8 @@ in API Blueprint's formal spec language.
 
 ### Get a Translation Table                                    [GET]
 
-Clients can retrieve the current translation table for this TSP's Open Telematics API for given language (provided in the request headers.)
+Clients can retrieve the current translation table for this TSP's Open Telematics API for given language (provided in
+the request headers.)
 
 **Access Controls**
 
@@ -2868,12 +3033,20 @@ Clients can retrieve the current translation table for this TSP's Open Telematic
 
 + Response 406
 
+        Language requested in Accept-Language header is unavailable
+
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2909,11 +3082,17 @@ it is expected that the 'use case based' API endpoints defined above will be of 
     + Attributes (Log Event)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2943,11 +3122,17 @@ it is expected that the 'use case based' API endpoints defined above will be of 
     + Attributes (Driver)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -2978,11 +3163,17 @@ it is expected that the 'use case based' API endpoints defined above will be of 
     + Attributes (Vehicle)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3013,11 +3204,17 @@ it is expected that the 'use case based' API endpoints defined above will be of 
     + Attributes (Message Receipt)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3052,11 +3249,17 @@ rules.
     + Attributes (Region Specific Break Rules)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3089,11 +3292,17 @@ available
     + Attributes (Region Specific Waivers)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3123,11 +3332,17 @@ available
     + Attributes (Stop Geographic Details)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3157,11 +3372,17 @@ available
     + Attributes (Vehicle Location Time)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3193,11 +3414,17 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
     + Attributes (Vehicle Flagged Event)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3227,11 +3454,17 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
     + Attributes (Vehicle Fault Code Event)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3261,11 +3494,17 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
     + Attributes (Flagged Vehicle Fault Code Event)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3295,11 +3534,17 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
     + Attributes (Vehicle Performance Event)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}
@@ -3331,11 +3576,17 @@ Summary statistics on performance of drivers.
     + Attributes (Driver Performance Summary)
 
 + Response 401
+    + Body
+
+            Authentication Required
     + Headers
 
             WWW-Authenticate: Basic realm="protected"
 
 + Response 429
+    + Body
+
+            Too Many Requests
     + Headers
 
             Retry-After: {implementation-defined}

--- a/apiary.apib
+++ b/apiary.apib
@@ -2998,6 +2998,10 @@ the request headers.)
 
         Language requested in Accept-Language header is unavailable
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3046,6 +3050,10 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 + Response 200 (application/json)
     + Attributes (Log Event)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3087,6 +3095,10 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 
 + Response 200 (application/json)
     + Attributes (Driver)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body
@@ -3131,6 +3143,10 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 + Response 200 (application/json)
     + Attributes (Vehicle)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3173,6 +3189,10 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 
 + Response 200 (application/json)
     + Attributes (Message Receipt)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body
@@ -3221,6 +3241,10 @@ rules.
 + Response 200 (application/json)
     + Attributes (Region Specific Break Rules)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3265,6 +3289,10 @@ available
 
 + Response 200 (application/json)
     + Attributes (Region Specific Waivers)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body
@@ -3357,6 +3385,10 @@ indicating the entryway onto a facility (i.e. where the truck should drive on ap
 + Response 200 (application/json)
     + Attributes (Vehicle Location Time)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3401,6 +3433,10 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 + Response 200 (application/json)
     + Attributes (Vehicle Flagged Event)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3442,6 +3478,10 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 
 + Response 200 (application/json)
     + Attributes (Vehicle Fault Code Event)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body
@@ -3485,6 +3525,10 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 + Response 200 (application/json)
     + Attributes (Flagged Vehicle Fault Code Event)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3526,6 +3570,10 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
 
 + Response 200 (application/json)
     + Attributes (Vehicle Performance Event)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body
@@ -3571,6 +3619,10 @@ Summary statistics on performance of drivers.
 + Response 200 (application/json)
     + Attributes (Driver Performance Summary)
 
++ Response 404 (text/plain)
+
+        Error: id Not Found
+
 + Response 401
     + Body
 
@@ -3612,6 +3664,10 @@ Summary statistics on performance of drivers.
 
 + Response 200 (application/json)
     + Attributes (State of Health)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body

--- a/apiary.apib
+++ b/apiary.apib
@@ -498,7 +498,13 @@ Telematics Data Model* for object descriptions as well.
 + dateTime          :             `2019-04-05T02:04:16Z` (required, string) - Date and time from the telematics device
 + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id associated with this log.
 + driverId          : `63A9F0EA7BB98050796B649E85481845` (required, string) - The id of the driver who created this log.
-+ distanceLastValid :                                117 (required, number) - The distance in km traveled since the last valid latitude, longitude pair the ELD measured with required accuracy in the ELD mandate
++ distanceLastValid :                              117.0 (required, number) - The distance traveled since the last valid latitude, longitude pair the ELD measured with required accuracy in the ELD mandate, in units given by the `distanceUnits` field
++ distanceUnits     :              `DISTANCEUNITS_MILES` (required, enum[string]) - The units of distance used to record the `distanceSinceLastValid` field. Units are specified in the Log Events so that the `eventDataChecksum` field can be unchangde from the value reported by a telematics device.
+
+    + Members
+        + `DISTANCEUNITS_MILES`      - distance measured in miles (mi)
+        + `DISTANCEUNITS_KILOMETRES` - distance measured in kilometres (km)
+
 + editDateTime                                           (string) - The date and time the log was edited. If the log has not been edited, this will not be set.
 
 + location                                               (required, Compliance Location) - An object with the location information for the log data, more details than lat/long for compliance purposes
@@ -2519,11 +2525,21 @@ Clients can retrieve the current translation table for this TSP's Open Telematic
 
             {
                 "data": [{
+                        "origin": "Log Event, distanceUnits",
+                        "msgid":  "DISTANCEUNITS_MILES",
+                        "msgstr": "distance measured in miles (mi)"
+                    },
+                    {
+                        "origin": "Log Event, distanceUnits",
+                        "msgid":  "DISTANCEUNITS_KILOMETRES",
+                        "msgstr": "distance measured in kilometres (km)"
+                    },
+                    {
                         "origin": "Log Event, origin",
                         "msgid": "ORIGIN_AUTOMATIC",
                         "msgstr": "Automatic recorded by device"
                     },
-                     {
+                    {
                         "origin": "Log Event, origin",
                         "msgid": "ORIGIN_MANUAL",
                         "msgstr": "Manual entry by driver"

--- a/apiary.apib
+++ b/apiary.apib
@@ -905,8 +905,8 @@ Telematics Data Model* for object descriptions as well.
 
 ### Flagged Event Thresholds (object)
 
-+ suddenThreshold:                           `3.13` (number) - the speed change threshold, above which a Vehicle Flagged Event of type `FLAGGEDTYPE_SUDDEN_STOP` or `FLAGGEDTYPE_SUDDEN_START` is created, in m/s/s
-+ collisionThreshold:                        `12.2` (number) - the speed change threshold, above which a Vehicle Flagged Event of type `FLAGGEDTYPE_COLLISION` is created, in m/s/s
++ suddenThreshold:                           `3.13` (number) - the ECU speed change threshold, above which a Vehicle Flagged Event of type `FLAGGEDTYPE_SUDDEN_STOP` or `FLAGGEDTYPE_SUDDEN_START` is created, in m/s/s
++ collisionThreshold:                        `12.2` (number) - the ECU speed change threshold, above which a Vehicle Flagged Event of type `FLAGGEDTYPE_COLLISION` is created, in m/s/s
 
 ### Vehicle Flagged Event (object)
 
@@ -917,7 +917,7 @@ Telematics Data Model* for object descriptions as well.
 + eventEnd          :             `2019-04-05T02:04:16Z` (required, string) - Date and time of the end of the event
 + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id associated with this event
 + eventComment      : `event type XXXX, (other details)` (string) - a free-form comment field. Can be used for e.g. identifying the type of event or other unstructured data
-+ thresholds                                             (Flagged Event Thresholds) - the thresholds that were active during this event
++ thresholds                                             (Flagged Event Thresholds) - the thresholds that were active and against which ECU speed was compared during this event
 + trigger                                                (required, enum[string]) - type flagged event
     + Members
         + `FLAGGEDTYPE_ROLL_STABILITY` - Roll stability flagged event

--- a/apiary.apib
+++ b/apiary.apib
@@ -193,6 +193,7 @@ All clients must implement certificate pinning. i.e. All client implementations 
 certificate pinning in the [OWASP MASVS](https://www.owasp.org/index.php/OWASP_Mobile_Security_Testing_Guide).
 
 # Working With Dates
+<a id="working_with_dates"></a>
 
 When exchanging dates as parameters to API methods or in responses from the API, you must ensure that
 they are formatted properly as an ISO 8601 string (format
@@ -335,7 +336,7 @@ specification.
 
 Addition of fields to the objects must be done such that it is not possible for the new extension fields to collide with
 other extensions or with future versions of the API; therefore, all fields added as extensions must be prefixed with
-`x_providerid_` where `providerid` is the provider ID (see [Provider Identifiers](#provider_identifiers) above for more
+`x_providerid_` where `providerid` is the provider ID (see [Provider Identifiers](#provider_identifiers) for more
 details).
 
 * Adding addional field/members to the data objects, when the data is needed by a motor freight carrier IS a valid extension to the OTAPI
@@ -373,12 +374,12 @@ interest of ensuring that the APIs are _useful_ to their intended users (motor f
 organize -- the API by these use cases. See the sections below for the API endpoints in those categories. For ease of
 reference, we summarize the use cases here:
 
-***Check Provider's State of Health***
+## Check Provider's State of Health
 
 Users of telematics that is highly integrated into their operations need assurances of the state of health of the
 Provider's services.
 
-***Data Export***
+## Data Export
 
 Motor freight carriers want to export all data from a TSP for a given time period. Where 'all data' for the purposes of
 this specification is all the data specified here and does not include any other proprietary data structures designed
@@ -386,7 +387,7 @@ and employed by the TSP. These data exports could be used by carriers to complet
 TSP outage or for research purposes offline or to restore data -- although this last potential use is _not_ a use case
 we aim to support here please see below on 'data import.'
 
-***Generate Records of Duty Status for Compliance***
+## Generate Records of Duty Status for Compliance
 
 Motor freight carriers use telematics systems to maintain Record of Duty Status (RODS) compliance. The TSP to the
 carrier will supply compliant records directly, without the need for the carrier to use the OTAPI. The carrier may use
@@ -399,12 +400,12 @@ used by regulators used truncated timestamps and the higher-resolution available
 events being out-of-order in the view of the regulators without special handling by the TSP. This is an example of the
 kinds of nuances that are handled by TPSs in their service offering and OTAPI is not meant to replace that service.
 
-***Driver Availability***
+## Driver Availability
 
 Motor freight carriers need to understand the availability of their drivers -- within the current regulatory context of
 those drivers -- so that the carrier can ensure regulatory compliance and, more importantly, driver safety.
 
-***Driver Route & Directions Communication***
+## Driver Route & Directions Communication
 
 Motor freight carriers update their Driver's destination and route during their trip. This allows them to react to
 changing conditions in weather, the needs of regulatory restrictions on hours, optimizing follow-on activities after a
@@ -412,52 +413,52 @@ trip, etc.
 
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
-***Driver Route & Directions Start***
+## Driver Route & Directions Start
 
 Motor freight carriers plan destinations and routes for their drivers and inform the drivers of the plan via the in-cab
 components of a telematics system.
 
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
-***Driver Route and Directions Done***
+## Driver Route and Directions Done
 
 Motor freight carriers receive notifications when Drivers have completed their trip.
 
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
-***Driver Messaging by Geo-Location***
+## Driver Messaging by Geo-Location
 
 Motor freight carriers use telematics systems to message their drivers for various reasons, not the least of which is to
 notify the drivers of dangerous weather conditions in their area.
 
-***Driver Messaging by Vehicle***
+## Driver Messaging by Vehicle
 
 Motor freight carriers also message their drivers by sending messages directly to a vehicle.
 
-***Vehicle Location Time History Tracking***
+## Vehicle Location Time History Tracking
 
 Motor freight carriers use telematics fleet Location Time History for multiple 'fleet dynamics modeling' use cases such
 as: Fuel Purchase Prediction, Fuel Consumption Performance Tracking, and Fleet Maintenance Planning.
 
-***Human Resources Process: Payroll***
+## Human Resources Process: Payroll
 
 Motor freight carriers use telematics systems to assist in payroll processing. This enables efficiencies at scale that
 are important to modern motor freight carrier operations.
 
-***Human Resources Process: Accident Report***
+## Human Resources Process: Accident Report
 
 Motor freight carriers use telematics systems to monitor their fleets for accidents.
 
-***Carrier Custom Business Intelligence***
+## Carrier Custom Business Intelligence
 
 Motor freight carriers use telematics systems for multiple, custom, business intelligence purposes where the overall
 health of their fleet is considered and fed into their own proprietary models.
 
-***Compliance and Safety Monitoring***
+## Compliance and Safety Monitoring
 
 Motor freight carriers use telematics systems to monitor compliance and safety for their operations.
 
-***In-Field Maintenance & Repair***
+## In-Field Maintenance & Repair
 
 Motor freight carriers use telematics systems to plan (and react to) maintenance needs of their fleets.
 
@@ -848,13 +849,15 @@ Telematics Data Model* for object descriptions as well.
 
 ### State of Health (object)
 
++ id                : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The id of this Message receipt object
++ providerId        :                 `api.provider.com` (required, string) - The unique 'Provider ID' of the TSP
++ dateTime:    `2019-04-05T02:04:16Z`                    (required, string) - Date and time of this service status (this is 'serverTime')
 + serviceStatus:        `SERVICESTATUS_OPERATIONAL`      (required, enum[string]) - the current status of the service
     + Members
         + `SERVICESTATUS_OPERATIONAL` - the service is operational
         + `SERVICESTATUS_DEGRADED_PERFORMANCE` - the service is operating, but with limitations
         + `SERVICESTATUS_PARTIAL_OUTAGE` - there are aspects of the service which are not presently available
         + `SERVICESTATUS_MAJOR_OUTAGE` - the service is unavailable
-+ dateTime:    `2019-04-05T02:04:16Z`                    (required, string) - Date and time of this service status (this is 'serverTime')
 + factors: `upstream server operational`, `authentication service operational` (array[string], fixed-type) - a list of contributing factors to the current service status. Providers may use this to communicate details about loss of service
 
 ### Vehicle Only Complete Telematics Records (object)
@@ -961,6 +964,14 @@ State of Health. They expect to receive either an 'all-clear' response indicatin
 issues with its services at the moment of query or some details describing the contributing factors that have led to
 less than optimal operation.
 
+To check the current state of health of the service they use
+
+* [Check Current State of Health](#check_current_state_of_health)
+
+To check the past 30 days worth of states of health they use
+
+* [Check Past 30d State of Health](#check_past_30d_state_of_health)
+
 ## Check Current State of Health                               [GET /v1.0/health/current]
 <a id="check_current_state_of_health"></a>
 
@@ -1004,7 +1015,8 @@ Clients must treat any response other than code 200, code 401, or code 429 as eq
 <a id="check_past_30d_state_of_health"></a>
 
 Clients can request the recent history of all service statuses. The response to this query will return all service
-status records (i.e. those returned via *Check Current State of Health*) from over the past 30 days.
+status records (i.e. those returned via [Check Current State of Health](#check_current_state_of_health)) from over th
+past 30 days.
 
 Clients must treat any response other than code 200, code 401, or code 429 as equivalent to `SERVICESTATUS_MAJOR_OUTAGE`.
 
@@ -1056,10 +1068,10 @@ data structures such that any TSP wanting to implement _import_ is enabled to do
 ***PII Separation***
 
 The carriers need to be able to deploy systems which do not touch PII -- as is treated in the Authorization section
-above. OTAPI implementations must provide for export of both *Vehicle Only Complete Telematics Records* and *Complete
-Telematics Records* objects so that systems which must be separated from PII can download the *Vehicle Only Complete
-Telematics Records* type. As is noted in the access controls below, requests for these data types
-deny access by the *Vehicle X* roles.
+above. OTAPI implementations must provide for export of both [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format)
+and [Complete Telematics Export Format](#complete_telematics_export_format) objects so that systems which must be separated
+from PII can download the [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) type. As is
+noted in the access controls below, requests for these data types deny access by the *Vehicle X* roles.
 
 ***Polling for Daily Files***
 
@@ -1079,7 +1091,7 @@ Note that the data export files will include both time-varying objects (those th
 also those that do not.
 
 * For time-varying objects: the files will only include whose associated time periods have an intesection with the
-requested time period (as per the details of the *Working With Dates* section above);
+requested time period (as per the details of the [Working With Dates](#working_with_dates) section above);
 
 * For non time-varying objects: the files will include all objects known to the TSP at the time of the request,
 regardless of the time period requested as defined by `start` and `stop` query parameters (included on the endpoints for
@@ -1093,32 +1105,33 @@ the daily export files.
 
 ***Complete Data Export***
 
-The *Complete Data Export* objects will contain all of the following object embedded, see [Complete Telematics Export Format](#complete_telematics_export_format) below for more details.
+The *Complete* objects will contain sets of all of the following objects embedded, see [Complete Telematics Export Format](#complete_telematics_export_format) for more details.
 
-* Vehicle
-* Vehicle Location Time History
-* Vehicle Flagged Event
-* Vehicle Performance Event
-* Stop Geographic Details
-* Vehicle Fault Code Event
-* Driver
-* Log Event
-* Region Specific Break Rules
-* Region Specific Waivers
-* Driver Performance Summary
-* State of Health
+* [Vehicle](#vehicle_object)
+* [Vehicle Location Time](#vehicle_location_time_object)
+* [Vehicle Flagged Event](#vehicle_flagged_event_object)
+* [Vehicle Performance Event](#vehicle_performance_event_object)
+* [Stop Geographic Details](#stop_geographic_details_object)
+* [Vehicle Fault Code Event](#vehicle_fault_code_event_object)
+* [Driver](#driver_object)
+* [Log Event](#log_event_object)
+* [Region Specific Break Rules](#region_specific_break_rules_object)
+* [Region Specific Waivers](#region_specific_waivers_object)
+* [Driver Performance Summary](#driver_performance_summary_object)
+* [Message Receipt](#message_receipts)
+* [State of Health](#state_of_health_object)
 
 ***Vehicle-Only Data Export***
 
-The *Vehicle Only Complete Telematics Records* objects will contain only the following embedded objects, see [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) for more details.
+The *Vehicle-Only* objects will contain sets of all of the following objects embedded, see [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) for more details.
 
-* Stop Geographic Details
-* Vehicle
-* Vehicle Location Time History
-* Vehicle Flagged Event
-* Vehicle Performance Event
-* Vehicle Fault Code Event
-* State of Health
+* [Vehicle](#vehicle_object)
+* [Vehicle Location Time](#vehicle_location_time_object)
+* [Vehicle Flagged Event](#vehicle_flagged_event_object)
+* [Vehicle Performance Event](#vehicle_performance_event_object)
+* [Stop Geographic Details](#stop_geographic_details_object)
+* [Vehicle Fault Code Event](#vehicle_fault_code_event_object)
+* [State of Health](#state_of_health_object)
 
 ## Complete Telematics Export Format                               [/v1.0/export/allrecords/status{?dayOf}]
 <a id="complete_telematics_export_format"></a>
@@ -1252,8 +1265,8 @@ kinds of nuances that are handled by TPSs in their service offering and OTAPI is
 Personnel responsible for compliance need to be able to create RODS based on information exported from OTAPI in the
 event a TSP is no longer available.
 
-See [Complete Telematics Export Format](#complete_telematics_export_format) above for more details on the file format
-which should contain sufficient data for this use case in the array of *Log Event* objects.
+See [Complete Telematics Export Format](#complete_telematics_export_format) for more details on the file format
+which should contain sufficient data for this use case in the array of [Log Event objects](#log_event_object).
 
 # Group Use Case Driver Availability
 
@@ -1261,23 +1274,24 @@ Motor freight carriers need to understand the availability of their drivers -- w
 those drivers -- so that the carrier can ensure regulatory compliance and, more importantly, driver safety.
 
 Both personnel and semi-automated systems responsible for planning and assigning driver routes want to model the current
-availability of a Driver; they retrieve all of the following 'driver availability factors' from that time up until the
-current moment, from which the current driver availability can be calculated.
+availability of a Driver. They have
 
-* Coarse Vehicle Location Time History
-* Vehicle Flagged Event
-* Log Event
+* a [Driver object id](#driver_object) for a given driver
 
-The same personnel and semi-automated systems will need to for breaks and exemption rules for drivers in those logs if
-they operate in regions with specific break rules or waivers.
+To calculate the current driver availablity they retrieve 'driver availability factors' from which the current driver
+availability can be calculated using
 
-* Region Specific Break Rules
-* Region Specific Waivers
+* [Get Driver Availability Factors](#get_driver_availability_factors) for a given [Driver object id](#driver_object) over a given period of time
+
+To consider also the breaks and exemption rules for driver in those logs (if they operate in regions with specific break
+rules or waivers) they use
+
+* [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) a given [Driver object id](#driver_object) over a given period of time
 
 In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
-this their systems send data _to_ the TSPs.
+this their systems send duty status changes to the TSP using
 
-* Externally Triggered Duty Status Change
+* [Update Driver Duty Status](#update_driver_duty_status) for a given [Driver object id](#driver_object).
 
 ## Get Driver Availability Factors                             [GET /v1.0/drivers/{driverId}/availability_factors/{?startTime,stopTime}]
 <a id="get_driver_availability_factors"></a>
@@ -1481,15 +1495,26 @@ trip, etc.
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
 Both personnel and semi-automated systems responsible for planning and assigning driver routes want to update the
-Driver's destination and route during a trip. They retrieve the driver availability factors for the time period from the
-driver's start of route up until the present (see [Get Driver Availability Factors](#get_driver_availability_factors)
-above for more details.)
+Driver's destination and route during a trip. They have
 
-In the process of updating the Driver's destination and route, the motor freight carrier sends the following _to_ the
-TSP
+* a [Driver object id](#driver_object) for a given driver
+* a [Vehicle object id](#vehicle_object) for a given vehicle
+* and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) they have both
+    * a *Vehicle Route object id* and
+    * a [Stop Geographic Details object id](#stop_geographic_details_object).
 
-* Stop Geographic Details
-* Stop Details
+To confirm that the given driver is still available to complete the route they retrieve the driver availability factors
+for the time period from the driver's start of route up until the present by using
+
+* [Get Driver Availability Factors](#get_driver_availability_factors) endpoint for a given [Driver object id](#driver_object) over a given period of time
+
+To change the route they use
+
+* [Update Driver Route Stop](#update_driver_route_stop) for a given [Vehicle object id](#vehicle_object) and a given *Vehicle Route object id*
+
+To update details (entry points, notes) of the route stop they use
+
+* [Update Stop Geographic Details](#update_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
 
 ## Update Driver Route Stop                                    [PUT /v1.0/vehicles/{vehicleId}/routes/{routeId}]
 <a id="update_driver_route_stop"></a>
@@ -1506,7 +1531,7 @@ change the destination of the route, hence also changing the stopId associated w
 
 + Parameters
     + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id to associate this route to
-    + routeId       : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route created, to be used for later updates to the route
+    + routeId           : `c6d2ff2e69c212d4eb9d64b629a46689` (required, string) - the id of the route created, to be used for later updates to the route
 
 + Request
     + Headers
@@ -1719,16 +1744,21 @@ components of a telematics system.
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
 Both personnel and semi-automated systems responsible for planning and assigning driver routes want to inform their
-drivers about their planned route before the driver starts the trip. Given the vehicle that the Driver will take on the
-route, they first check the vehicle for any faults or alarms in the past 24h by querying this endpoint.
+drivers about their planned route before the driver starts the trip. They have
 
-* Vehicle Flagged Event
+* a [Vehicle object id](#vehicle_object) for a given vehicle
 
-Then the trip start and stop destination is sent to the driver along with any other instructions (such as which trailers
-to take). A successful creation of a route will yield a response indicating the routeId to use in further updates or
-modifications to the route.
+To first check the vehicle for any faults or alarms in the past 24h they use
 
-* Externally Sourced Route Start Stop Details
+* [Get Vehicle Flagged Events](#get_vehicle_flagged_events) for a given [Vehicle object id](#vehicle_object) over a given period of time
+
+Assuming the vehicle is good to go, then they send trip start and stop destinations to the driver along with any other
+instructions (such as which trailers to take) using
+
+* [Create a Vehicle Route](#create_a_vehicle_route) for a given [Vehicle object id](#vehicle_object)
+
+A successful creation of a route will yield a *Route object id* in the response to use in further updates or modifications
+to the route.
 
 ## Get Vehicle Flagged Events                                  [GET /v1.0/vehicles/{vehicleId}/flagged_events/{?startTime,stopTime}]
 <a id="get_vehicle_flagged_events"></a>
@@ -1898,15 +1928,25 @@ Motor freight carriers receive notifications when Drivers have completed their t
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
 Both personnel and semi-automated systems responsible for planning and assigning driver routes want to be notified of a
-completed trip, along with the driver information about duty on the trip. They follow the feed of:
+completed trip, along with the driver information about duty on the trip. They have
 
-* Log Event
+* a [Driver object id](#driver_object) for a given driver
+* and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) and may have optionally
+[updated the driver's Route Stop](#update_driver_route_stop) or [updated the *Stop Geographic Details*](#update_stop_geographic_details)
+they hence have both
+    * a *Vehicle Route object id* and
+    * a [Stop Geographic Details object id](#stop_geographic_details_object).
 
-And mark trips completed based on the Log Event context; at the end of a trip they also query for the most recent
+So that they can react to the route completing in 'real-time' they are following the feed of [Log Events](#log_event_object) using
 
-* Stop Geographic Details
+* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
 
-to receive updates on changes to gates, access, repairs etc at the destination (see [Get Stop Geographic Details](#get_stop_geographic_details) above for more details.)
+They mark trips completed based on matching a [Log Event object](#log_event_object) in the feed which matches a given
+[Driver object id](#driver_object) and also has a status indicating that the route is complete.
+
+At the end of trips they also query for any updates on changes to gates, access, repairs etc at the destination using
+
+* [Get Stop Geographic Details](#get_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
 
 ## Follow Fleet Log Events                                     [GET /v1.0/event_logs/feed{?token}]
 <a id="follow_fleet_log_events"></a>
@@ -1960,14 +2000,18 @@ Motor freight carriers use telematics systems to message their drivers for vario
 notify the drivers of dangerous weather conditions in their area.
 
 Personnel responsible for planning and assigning driver routes want to send messages to drivers in a particular
-geographic region. They query the API for the most recent
+geographic region. They have
 
-* Vehicle Location Time History
+* a target geographic area, to which they want to send messages
 
-of all vehicles; then filtering-out all vehicles outside the particular geographic region, then send messages to each
-vehicle by sending data _to_ the TSP:
+To determine which vehicles presently lie within the geographic area they get the current location of all fleet vehicles
+using
 
-* Externally Sourced Vehicle Display Messages
+* [Get Fleet Latest Locations](#get_fleet_latest_locations)
+
+Then, for each [Vehicle object id](#vehicle_object) which lies within the geographic area they send it a message using
+
+* [Send Message to a Vehicle](#send_message_to_a_vehicle) for a given [Vehicle object id](#vehicle_object)
 
 ## Get Fleet Latest Locations                                  [GET /v1.0/fleet/locations/latest{?page,count}]
 <a id="get_fleet_latest_locations"></a>
@@ -2086,28 +2130,30 @@ Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a giv
 
             Retry-After: {implementation-defined}
 
+
 # Group Use Case Driver Messaging by Vehicle
 
 Motor freight carriers also message their drivers by sending messages directly to a vehicle.
 
-Personnel responsible for planning and assigning driver routes want to send a message to a driver's vehicle. They send
-data _to_ the TSP for a given vehicle:
+Personnel responsible for planning and assigning driver routes want to send a message to a driver's vehicle. They have
 
-* Externally Sourced Vehicle Display Messages
+* a [Vehicle object id](#vehicle_object) to which they wish to send a message
 
-(see [Send Message to a Vehicle](#send_message_to_a_vehicle) above for more details.)
+they send the vehicle a message using
 
-# Group Use Case Vehicle Location Time History Tracking
+* [Send Message to a Vehicle](#send_message_to_a_vehicle) for a given [Vehicle object id](#vehicle_object)
+
+
+# Group Use Case Vehicle Location Time History Processing
 
 Motor freight carriers use telematics fleet Location Time History for multiple 'fleet dynamics modeling' use cases such
-as: Fuel Purchase Prediction, Fuel Consumption Performance Tracking, and Fleet Maintenance Planning.
+as: Fuel Purchase Prediction, Fuel Consumption Performance Tracking, and Fleet Maintenance Planning. They have
 
-Autonomous analysis and reporting systems want to get the Location Time History of the fleet over a particular time
-period. They query the API for
+* a target time period, over which they want to perform an analysis of fleet location time history
 
-* Vehicle Location Time History
+To perform the analysis on fleet location time history they use
 
-of all vehicles over a given time period.
+* [Get Fleet Location History](#get_fleet_location_history) for a given time period
 
 ## Get Fleet Location History                                  [GET /v1.0/fleet/locations/{?startTime,stopTime,page,count}]
 <a id="get_fleet_location_history"></a>
@@ -2169,29 +2215,28 @@ of all vehicles over a given time period.
 Motor freight carriers use telematics systems to assist in payroll processing. This enables efficiencies at scale that
 are important to modern motor freight carrier operations.
 
-Automated payroll/HR systems want to receive Log Events and convert these into payroll tracking entries. To do
-this they follow a feed of:
+Automated payroll/HR systems want to receive Log Events and convert these into payroll tracking entries.
 
-* Log Event
+To do create payroll tracking entries in 'real-time' they follow the feed of [Log Events](#log_event_object) using
 
-(see [Follow Fleet Log Events](#follow_fleet_log_events) above for more details) and they query for breaks and exemption
-rules for drivers in those logs:
+* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
 
-* Region Specific Break Rules
-* Region Specific Waivers
+furthermore -- if they operate in regions with specific break rules or waivers are applicable -- they use
 
-(see [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) above for more details.)
+* [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) for each [Driver object id](#driver_object) in the
+feed for the times of interest to the payroll tracking entries
 
 In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
-this their systems send data _to_ the TSPs:
+this their systems send data _to_ the TSPs using
 
-* Externally Triggered Duty Status Change
+* [Update Driver Duty Status](#update_driver_duty_status) endpoint for a given [Driver object id](#driver_object).
 
-(see [Update Driver Duty Status](#update_driver_duty_status) above for more details.) HR staff want to associate their
-Driver's with metadata for use by the TSP. e.g. the region of governance for duty breaks and exemptions. To do this
-their systems send data _to_ the TSPs:
+and the duty status changes are reflected in the [Follow Fleet Log Events](#follow_fleet_log_events) endpoint.
 
-* Externally Sourced Driver Info
+To associate their Driver's with metadata for use by the TSP (e.g. the region of governance for duty breaks and
+exemptions) they use
+
+* [Update Driver Info](#update_driver_info) for a given [Driver object id](#driver_object).
 
 ## Update Driver Info                                        [PATCH /v1.0/drivers/{driverId}]
 <a id="update_driver_info"></a>
@@ -2284,11 +2329,11 @@ Clients can request updates to the TSP's managed user accounts for drivers by se
 Motor freight carriers use telematics systems to monitor their fleets for accidents.
 
 Semi-automated systems want to receive notification of any accidents in their fleet and handle accident reports
-internally according to their own processes. To do this they follow a feed of:
+internally according to their own processes.
 
-* Log Event
+To do respond to accidents in 'real-time' they follow the feed of [Log Events](#log_event_object) using
 
-(see [Follow Fleed Log Events](#follow_fleet_log_events) above for more details.)
+* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
 
 # Group Use Case Carrier Custom Business Intelligence
 
@@ -2296,22 +2341,19 @@ Motor freight carriers use telematics systems for multiple, custom, business int
 health of their fleet is considered and fed into their own proprietary models.
 
 Automated and semi-automated analysis and reporting systems want to get the overall fleet health status for a particular
-time period. They query the API for
+time period.
 
-* Coarse Vehicle Location Time History
-* Flagged Vehicle Fault Code Event
-* Vehicle Performance Event
-* Vehicle Fault Code Event
+To process the fleet state over a target time period they use
 
-of all vehicles over a given time period.
+* [Get Fleet Vehicle Info](#get_fleet_vehicle_info) for a given time period
 
-For certain use cases, they may opt to *follow* a feed of the above objects instead. See [Follow Fleet Vehicle Info](#follow_fleet_vehicle_info) below.
+To process and respond to fleet status in 'real-time' they follow a feed using
 
-They may also follow-up with queries of the hi-resolution time history of the fleet for a given time period:
+* [Follow Fleet Vehicle Info](#follow_fleet_vehicle_info) for all vehicles
 
-* Vehicle Location Time History
+To follow-up with queries of the hi-resolution time history of the fleet for a given time period they use
 
-(see [Get Fleet Location History](#get_fleet_location_history) above for more details.)
+* [Get Fleet Location History](#get_fleet_location_history) for a given time period.
 
 ## Get Fleet Vehicle Info                                      [GET /v1.0/fleet/infos/{?startTime,stopTime}]
 <a id="get_fleet_vehicle_info"></a>
@@ -2424,15 +2466,19 @@ entries with each query in the polling.
 
 Motor freight carriers use telematics systems to monitor compliance and safety for their operations.
 
-Personnel responsible for safety and compliance want to review the safety and compliance of their drivers. For a given
-driver they retrieve from the TSP:
+Personnel responsible for safety and compliance want to review the safety and compliance of their drivers. They have:
 
-* Driver Performance Summary
+* a [Driver object id](#driver_object) for a given driver
+* a time period of interest
 
-Motor freight carriers want to create, delete and modify driver login credentials that the drivers will use in the
-field. They send data _to_ the TSP:
+To obtain the information necessary to review for safety and compliance they use
 
-* External TSP Portal User Management
+* [Get Driver Performance Summaries](#get_driver_performance_summaries) for a given [Driver object id](#driver_object) and for a given time period
+
+To create, delete and modify driver login credentials that the drivers will use in the
+field and to which the [Driver Performance Summary objects](#driver_performance_summary_object) are associate they use
+
+* [Update Driver TSP Portal Account](#update_driver_tsp_portal_account) for a given [Driver object id](#driver_object)
 
 ## Get Driver Performance Summaries                            [GET /v1.0/drivers/{driverId}/performance_summaries/{?startTime,stopTime}]
 <a id="get_driver_performance_summaries"></a>
@@ -2563,14 +2609,15 @@ Clients can request updates to the TSP's portal user accounts for drivers by sen
 Motor freight carriers use telematics systems to plan (and react to) maintenance needs of their fleets.
 
 Automated back-end systems at the motor freight carrier want to be notified of any vehicle issues requiring maintenance.
-The systems determine which events require maintenance by following a feed of:
 
-* Vehicle Fault Code Event
+To determine which events require maintenance in 'real-time' they follow a feed using
 
-In the event that an issue requiring maintenance must be resolved in the field, the system will query to get the most
-recent vehicle location
+* [Follow Fleet Fault Code Events](#follow_fleet_fault_code_events) for all fleet vehicles
 
-* Vehicle Location Time History
+To dispatch assitance to the location of a given [Vehicle object id](#vehicle_object) -- in the event that an issue
+requiring maintenance must be resolved in the field -- they obtain the most recent vehicle location using
+
+* [Get Vehicle Location History](#get_vehicle_location_history) for a given [Vehicle object id](#vehicle_object) over the most recent time period
 
 ## Follow Fleet Fault Code Events                              [GET /v1.0/fleet/faults/feed{?token}]
 <a id="follow_fleet_fault_code_events"></a>
@@ -3085,6 +3132,7 @@ models here along with simple 'get by id' APIs. These simple APIs could be usefu
 it is expected that the 'use case based' API endpoints defined above will be of more use in integration than these.
 
 ## Log Event Object                                                [/v1.0/event_logs/{id}]
+<a id="log_event_object"></a>
 
 + Parameters
     + id            (string) - ID of the Log Event of interest
@@ -3126,6 +3174,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
             Retry-After: {implementation-defined}
 
 ## Driver Object                                                   [/v1.0/drivers/{id}]
+<a id="driver_object"></a>
 
 + Parameters
     + id            (string) - ID of a Driver object
@@ -3167,6 +3216,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
             Retry-After: {implementation-defined}
 
 ## Vehicle Object                                                  [/v1.0/vehicles/{id}]
+<a id="vehicle_object"></a>
 
 + Parameters
     + id            (string) - ID of a Vehicle object
@@ -3209,6 +3259,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
             Retry-After: {implementation-defined}
 
 ## Message Receipt Object                                          [/v1.0/message_receipts/{id}]
+<a id="message_receipt_object"></a>
 
 + Parameters
     + id            (string) - ID of a Message Receipt object
@@ -3252,6 +3303,7 @@ it is expected that the 'use case based' API endpoints defined above will be of 
 
 
 ## Region Specific Break Rules Object                              [/v1.0/region_specific_breaks/{id}]
+<a id="region_specific_break_rules_object"></a>
 
 Rules governing driver brakes for the specific region of governance of the driver in question. The rules are defined
 only by the region that is dictating the rules, clients are expected to interpret the region to realize specific break
@@ -3297,6 +3349,7 @@ rules.
             Retry-After: {implementation-defined}
 
 ## Region Specific Waivers Object                                  [/v1.0/region_specific_waivers/{id}]
+<a id="region_specific_waivers_object"></a>
 
 Waivers and exceptions for the specific region of governance of the driver in question. One entity per day of a waiver
 available
@@ -3341,6 +3394,7 @@ available
             Retry-After: {implementation-defined}
 
 ## Stop Geographic Details Object                                  [/v1.0/stops/{id}]
+<a id="stop_geographic_details_object"></a>
 
 + Parameters
     + id            (string) - ID of the Stop Geographic Details of interest
@@ -3382,6 +3436,7 @@ available
             Retry-After: {implementation-defined}
 
 ## Vehicle Location Time Object                                    [/v1.0/fleet/locations/{id}]
+<a id="vehicle_location_time_object"></a>
 
 + Parameters
     + id            (string) - ID of the Vehicle Location Time of interest
@@ -3423,6 +3478,7 @@ available
             Retry-After: {implementation-defined}
 
 ## Vehicle Flagged Event Object                                    [/v1.0/fleet/flagged_events/{id}]
+<a id="vehicle_flagged_event_object"></a>
 
 The purpose of the flagged events is to flag potential saftey issues for motor freight carrier staff to validate
 
@@ -3466,6 +3522,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
             Retry-After: {implementation-defined}
 
 ## Vehicle Fault Code Event Object                                 [/v1.0/fleet/faults/{id}]
+<a id="vehicle_fault_code_event_object"></a>
 
 + Parameters
     + id            (string) - ID of the Vehicle Fault Code Event of interest
@@ -3507,6 +3564,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
             Retry-After: {implementation-defined}
 
 ## Flagged Vehicle Fault Code Event Object                         [/v1.0/fleet/flagged_faults/{id}]
+<a id="flagged_vehicle_fault_code_event_object"></a>
 
 + Parameters
     + id            (string) - ID of the Flagged Vehicle Fault Code Event of interest
@@ -3548,6 +3606,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
             Retry-After: {implementation-defined}
 
 ## Vehicle Performance Event Object                                [/v1.0/fleet/performance_events/{id}]
+<a id="vehicle_performance_event_object"></a>
 
 + Parameters
     + id            (string) - ID of the Vehicle Performance Event of interest
@@ -3589,6 +3648,7 @@ The purpose of the flagged events is to flag potential saftey issues for motor f
             Retry-After: {implementation-defined}
 
 ## Driver Performance Summary Object                               [/v1.0/driver_performance_summaries/{id}]
+<a id="driver_performance_summary_object"></a>
 
 Summary statistics on performance of drivers.
 
@@ -3614,6 +3674,48 @@ Summary statistics on performance of drivers.
 
 + Response 200 (application/json)
     + Attributes (Driver Performance Summary)
+
++ Response 401
+    + Body
+
+            Authentication Required
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Body
+
+            Too Many Requests
+    + Headers
+
+            Retry-After: {implementation-defined}
+
+## State of Health Object                                          [/v1.0/health/{id}]
+<a id="state_of_health_object"></a>
+
++ Parameters
+    + id            (string) - ID of the State of Health object of interest
+
++ Attributes (State of Health)
+
+### Get a State of Health by its ID                 [GET]
+<a id="get_a_state_of_health_by_its_id"></a>
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | ALLOW         | ALLOW      | ALLOW      | ALLOW      |
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (State of Health)
 
 + Response 401
     + Body

--- a/apiary.apib
+++ b/apiary.apib
@@ -1595,7 +1595,8 @@ Clients can retrieve all the flagged vehicle events of a given vehicle over a gi
             Authorization: Basic YWRtaW46YWRtaW4=
 
 + Response 200 (application/json)
-    + Attributes (Vehicle Flagged Event)
+    + Attributes (object)
+        + data (array[Vehicle Flagged Event], fixed-type)
 
 + Response 400 (text/plain)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -816,6 +816,17 @@ Telematics Data Model* for object descriptions as well.
 + cmvVIN                                                 (required, string) - the CMV VIN
 + licensePlate                                           (required, string) - the vehicle license plate
 
+### Message Receipt (object)
+
++ id                : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The id of this Message receipt object
++ providerId        :                 `api.provider.com` (required, string) - The unique 'Provider ID' of the TSP
++ serverTime        :             `2019-04-05T02:04:16Z` (required, string) - Date and time when the message receipt was last updated in the TSP
++ subject                                                (string) - the 'subject-line' of the delivered message
++ message                                                (required, string) - the message delivered
++ sentTime          :             `2019-04-05T02:04:16Z` (required, string) - Date and time when the message was sent to the vehicle
++ deliveredTime     :             `2019-04-05T02:04:16Z` (required, string) - Date and time when the message was delivered to the vehicle
++ readTime          :             `2019-04-05T02:04:16Z` (string) - Date and time when the message was displayed to driver
+
 ### Token Translation (object)
 
 + origin :                `Log Event, malfunction` (string) - optional note of origin of token to be translated
@@ -854,6 +865,7 @@ Telematics Data Model* for object descriptions as well.
 + regionSpecificBreakRules                               (array[Region Specific Break Rules], fixed-type) - Any of the Region Specific Break Rules objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
 + regionSpecificWaivers                                  (array[Region Specific Waivers], fixed-type) - Any of the Region Specific Waivers objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
 + driverPerformanceSummaries                             (array[Driver Performance Summary], fixed-type) - Any of the Driver Performance Summary objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
++ displayMessageReceipts                                 (array[Message Receipt], fixed-type) - Any of the Message Receipt objects known to the TSP at the time of the request whose associated time periods have an intersection with the requested time period
 
 ## Data Structures
 
@@ -1927,6 +1939,8 @@ Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a giv
             }
 
 + Response 201 (application/json)
+    + Attributes (object)
+        + messageReceiptId:   `FC5E038D38A57032085441E7FE7010B0` (required, string) - the id of the Message Receipt object that will track the delivery- and option display-timestamps of this message
 
 + Response 204
 
@@ -2956,6 +2970,42 @@ it is expected that the 'use case based' API endpoints defined above will be of 
     + Headers
 
             Retry-After: {implementation-defined}
+
+## Message Receipt Object                                          [/v1.0/message_receipts/{id}]
+
++ Parameters
+    + id            (string) - ID of a Message Receipt object
+
++ Attributes (Vehicle)
+
+
+### Get a Message Receipt by its ID                            [GET]
+
+**Access Controls**
+
+
+|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
+|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
+|Access:| ALLOW       | ALLOW        | ALLOW      | ALLOW       | **DENY**      | **DENY**   | **DENY**   | ALLOW      |
+
++ Request
+    + Headers
+
+            Authorization: Basic YWRtaW46YWRtaW4=
+
++ Response 200 (application/json)
+    + Attributes (Message Receipt)
+
++ Response 401
+    + Headers
+
+            WWW-Authenticate: Basic realm="protected"
+
++ Response 429
+    + Headers
+
+            Retry-After: {implementation-defined}
+
 
 ## Region Specific Break Rules Object                              [/v1.0/region_specific_breaks/{id}]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -596,7 +596,7 @@ They mark trips completed based on matching a [Log Event object](#log_event_obje
 
 At the end of trips they also query for any updates on changes to gates, access, repairs etc at the destination using
 
-* [Get Stop Geographic Details](#get_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
+* [Get Stop Geographic Details by its ID](#get_a_region_specific_waivers_by_its_id) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
 
 ## Driver Messaging by Geo-Location
 
@@ -1708,57 +1708,7 @@ change the destination of the route, hence also changing the stopId associated w
 
             Retry-After: {implementation-defined}
 
-## Route Stop Geographic Details                                   [/v1.0/stops/{stopId}]
-
-### Get Stop Geographic Details                                [GET]
-<a id="get_stop_geographic_details"></a>
-
-Clients can retrieve the _geographic details_ of a stop; the *Stop Geographic Details* are the specific location for the
-truck and trailer to park and a polygon of geographic points indicating the entryway onto a facility (i.e. where the
-truck should drive on approach).
-
-**Access Controls**
-
-
-|Role:  |Vehicle Query|Vehicle Follow|Driver Query|Driver Follow|Driver Dispatch|Driver Duty |HR          |Admin       |
-|-------|-------------|--------------|------------|-------------|---------------|------------|------------|------------|
-|Access:| **DENY**    | **DENY**     | **DENY**   | **DENY**    | ALLOW         | **DENY**   | **DENY**   | ALLOW      |
-
-+ Parameters
-    + stopId           : `b4655ce13cb3e137013d852bd7d687ae` (required, string) - The stop id to update
-
-+ Request
-    + Headers
-
-            Authorization: Basic YWRtaW46YWRtaW4=
-
-+ Response 200 (application/json)
-
-    + Attributes (Stop Geographic Details)
-
-+ Response 204
-
-+ Response 404 (text/plain)
-
-        Error: stopId Not Found
-
-+ Response 401
-    + Body
-
-            Authentication Required
-    + Headers
-
-            WWW-Authenticate: Basic realm="protected"
-
-+ Response 429
-    + Body
-
-            Too Many Requests
-    + Headers
-
-            Retry-After: {implementation-defined}
-
-### Update Stop Geographic Details                           [PATCH]
+## Update Stop Geographic Details                           [PATCH /v1.0/stops/{stopId}]
 <a id="update_stop_geographic_details"></a>
 
 Clients can update the _geographic details_ of a stop; the *Stop Geographic Details* are the specific location for the
@@ -3335,6 +3285,9 @@ available
 ## Stop Geographic Details Object                                  [/v1.0/stops/{id}]
 <a id="stop_geographic_details_object"></a>
 
+*Stop Geographic Details* are the specific location for the truck and trailer to park and a polygon of geographic points
+indicating the entryway onto a facility (i.e. where the truck should drive on approach).
+
 + Parameters
     + id            (string) - ID of the Stop Geographic Details of interest
 
@@ -3357,6 +3310,10 @@ available
 
 + Response 200 (application/json)
     + Attributes (Stop Geographic Details)
+
++ Response 404 (text/plain)
+
+        Error: id Not Found
 
 + Response 401
     + Body

--- a/apiary.apib
+++ b/apiary.apib
@@ -623,6 +623,11 @@ Telematics Data Model* for object descriptions as well.
 + ignitionCrankContact:                           false  (required, boolean) - ignition crank contact state at time of event
 + ignitionAidContact:                             false  (required, boolean) - ignition aid contact state at time of event
 
+### Flagged Event Thresholds (object)
+
++ suddenThreshold:                           `3.13` (number) - the speed change threshold, above which a Vehicle Flagged Event of type `FLAGGEDTYPE_SUDDEN_STOP` or `FLAGGEDTYPE_SUDDEN_START` is created, in m/s/s
++ collisionThreshold:                        `12.2` (number) - the speed change threshold, above which a Vehicle Flagged Event of type `FLAGGEDTYPE_COLLISION` is created, in m/s/s
+
 ### Vehicle Flagged Event (object)
 
 + id                : `C4CA4238A0B923820DCC509A6F75849B` (required, string) - The unique identifier for the specific Entity object in the system.
@@ -632,6 +637,7 @@ Telematics Data Model* for object descriptions as well.
 + eventEnd          :             `2019-04-05T02:04:16Z` (required, string) - Date and time of the end of the event
 + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id associated with this event
 + eventComment      : `event type XXXX, (other details)` (string) - a free-form comment field. Can be used for e.g. identifying the type of event or other unstructured data
++ thresholds                                             (Flagged Event Thresholds) - the thresholds that were active during this event
 + trigger                                                (required, enum[string]) - type flagged event
     + Members
         + `FLAGGEDTYPE_ROLL_STABILITY` - Roll stability flagged event

--- a/apiary.apib
+++ b/apiary.apib
@@ -776,7 +776,7 @@ Telematics Data Model* for object descriptions as well.
 + dateTime          :             `2019-04-05T02:04:16Z` (required, string) - Date and time from the telematics device
 + vehicleId         : `21232F297A57A5A743894A0E4A801FC3` (required, string) - The vehicle id associated with this log.
 + driverId          : `63A9F0EA7BB98050796B649E85481845` (required, string) - The id of the driver who created this log.
-+ distanceLastValid :                              117.0 (required, number) - The distance traveled since the last valid latitude, longitude pair the ELD measured with required accuracy in the ELD mandate, in units given by the `distanceUnits` field
++ distanceLastValid :                              117.0 (required, number) - The distance traveled since the last valid latitude, longitude pair the ELD measured with required accuracy in the ELD mandate, in units given by the `distanceUnits` field. TSPs may provide distance in miles or in kilometres but are not required to provide both.
 + distanceUnits     :              `DISTANCEUNITS_MILES` (required, enum[string]) - The units of distance used to record the `distanceSinceLastValid` field. Units are specified in the Log Events so that the `eventDataChecksum` field can be unchangde from the value reported by a telematics device.
 
     + Members

--- a/apiary.apib
+++ b/apiary.apib
@@ -379,13 +379,99 @@ reference, we summarize the use cases here:
 Users of telematics that is highly integrated into their operations need assurances of the state of health of the
 Provider's services.
 
+The IT and operations staff responsible for system uptime want to query the Open Telematics API provider (TSP) Provider
+State of Health. They expect to receive either an 'all-clear' response indicating that the provider is not aware of any
+issues with its services at the moment of query or some details describing the contributing factors that have led to
+less than optimal operation.
+
+To check the current state of health of the service they use
+
+* [Check Current State of Health](#check_current_state_of_health)
+
+To check the past 30 days worth of states of health they use
+
+* [Check Past 30d State of Health](#check_past_30d_state_of_health)
+
 ## Data Export
 
-Motor freight carriers want to export all data from a TSP for a given time period. Where 'all data' for the purposes of
+Motor freight carriers want to export all data from a TSP on a daily basis. Where 'all data' for the purposes of
 this specification is all the data specified here and does not include any other proprietary data structures designed
 and employed by the TSP. These data exports could be used by carriers to complete mandatory processes during times of
-TSP outage or for research purposes offline or to restore data -- although this last potential use is _not_ a use case
-we aim to support here please see below on 'data import.'
+TSP outage or to restore data -- although this last potential use is _not_ a use case we aim to support in OTAPI.
+
+***Data Import***
+
+The carriers would also like to be able to use the exported data in an 'import' to a second TSP or new instances of the
+same TSP. This is not an use case which this specification will attempt to support; however, we will aim to design the
+data structures such that any TSP wanting to implement _import_ is enabled to do so (c.f. 'Provider ID').
+
+***PII Separation***
+
+The carriers need to be able to deploy systems which do not touch PII -- as is treated in the Authorization section
+above. OTAPI implementations must provide for export of both [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format)
+and [Complete Telematics Export Format](#complete_telematics_export_format) objects so that systems which must be separated
+from PII can download the [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) type. As is
+noted in the access controls below, requests for these data types deny access by the *Vehicle X* roles.
+
+***Polling for Daily Files***
+
+The IT staff and automated systems that want to retreive the data exports on a daily basis will do so by polling the
+server for the status of the given's days complete record. The polling endpoint will either indicate that the file is
+not yet ready, or respond with a redirect to a location serving the complete file (statically).
+
+Implementors are free to make the files available for download from any service they choose. If the service hosting the
+files for download exposes endpoints under that of the OTAPI endpoints then the same authentication and authorization
+schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible
+without any authentication or authorization and the client is expected to be configured with the appropriate credentials
+for download independently of responses from the OTAPI server.
+
+***Time-base for Data Export***
+
+Note that the data export files will include both time-varying objects (those that have time associated with them) and
+also those that do not.
+
+* For time-varying objects: the files will only include whose associated time periods have an intesection with the
+requested time period (as per the details of the [Working With Dates](#working_with_dates) section above);
+
+* For non time-varying objects: the files will include all objects known to the TSP at the time of the request,
+regardless of the time period requested as defined by `start` and `stop` query parameters (included on the endpoints for
+API consistency under `/export/...`)
+
+Furthermore, the event and object times considered in the time queries for data export use *received times* (as opposed
+the default policy of relying on *creation times*). These are the times when the event or object was received, recorded
+and/or made available by the OTAPI server. This could pose problems for processing exported data for RODS compliance as
+multiple files may need to be processed in high-latency situations; however, the alternative is allow for data loss in
+the daily export files.
+
+***Complete Data Export***
+
+The *Complete* objects will contain sets of all of the following objects embedded, see [Complete Telematics Export Format](#complete_telematics_export_format) for more details.
+
+* [Vehicle](#vehicle_object)
+* [Vehicle Location Time](#vehicle_location_time_object)
+* [Vehicle Flagged Event](#vehicle_flagged_event_object)
+* [Vehicle Performance Event](#vehicle_performance_event_object)
+* [Stop Geographic Details](#stop_geographic_details_object)
+* [Vehicle Fault Code Event](#vehicle_fault_code_event_object)
+* [Driver](#driver_object)
+* [Log Event](#log_event_object)
+* [Region Specific Break Rules](#region_specific_break_rules_object)
+* [Region Specific Waivers](#region_specific_waivers_object)
+* [Driver Performance Summary](#driver_performance_summary_object)
+* [Message Receipt](#message_receipts)
+* [State of Health](#state_of_health_object)
+
+***Vehicle-Only Data Export***
+
+The *Vehicle-Only* objects will contain sets of all of the following objects embedded, see [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) for more details.
+
+* [Vehicle](#vehicle_object)
+* [Vehicle Location Time](#vehicle_location_time_object)
+* [Vehicle Flagged Event](#vehicle_flagged_event_object)
+* [Vehicle Performance Event](#vehicle_performance_event_object)
+* [Stop Geographic Details](#stop_geographic_details_object)
+* [Vehicle Fault Code Event](#vehicle_fault_code_event_object)
+* [State of Health](#state_of_health_object)
 
 ## Generate Records of Duty Status for Compliance
 
@@ -400,10 +486,36 @@ used by regulators used truncated timestamps and the higher-resolution available
 events being out-of-order in the view of the regulators without special handling by the TSP. This is an example of the
 kinds of nuances that are handled by TPSs in their service offering and OTAPI is not meant to replace that service.
 
+Personnel responsible for compliance need to be able to create RODS based on information exported from OTAPI in the
+event a TSP is no longer available.
+
+See [Complete Telematics Export Format](#complete_telematics_export_format) for more details on the file format
+which should contain sufficient data for this use case in the array of [Log Event objects](#log_event_object).
+
 ## Driver Availability
 
 Motor freight carriers need to understand the availability of their drivers -- within the current regulatory context of
 those drivers -- so that the carrier can ensure regulatory compliance and, more importantly, driver safety.
+
+Both personnel and semi-automated systems responsible for planning and assigning driver routes want to model the current
+availability of a Driver. They have
+
+* a [Driver object id](#driver_object) for a given driver
+
+To calculate the current driver availablity they retrieve 'driver availability factors' from which the current driver
+availability can be calculated using
+
+* [Get Driver Availability Factors](#get_driver_availability_factors) for a given [Driver object id](#driver_object) over a given period of time
+
+To consider also the breaks and exemption rules for driver in those logs (if they operate in regions with specific break
+rules or waivers) they use
+
+* [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) a given [Driver object id](#driver_object) over a given period of time
+
+In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
+this their systems send duty status changes to the TSP using
+
+* [Update Driver Duty Status](#update_driver_duty_status) for a given [Driver object id](#driver_object).
 
 ## Driver Route & Directions Communication
 
@@ -413,6 +525,28 @@ trip, etc.
 
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
+Both personnel and semi-automated systems responsible for planning and assigning driver routes want to update the
+Driver's destination and route during a trip. They have
+
+* a [Driver object id](#driver_object) for a given driver
+* a [Vehicle object id](#vehicle_object) for a given vehicle
+* and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) they have both
+    * a *Vehicle Route object id* and
+    * a [Stop Geographic Details object id](#stop_geographic_details_object).
+
+To confirm that the given driver is still available to complete the route they retrieve the driver availability factors
+for the time period from the driver's start of route up until the present by using
+
+* [Get Driver Availability Factors](#get_driver_availability_factors) endpoint for a given [Driver object id](#driver_object) over a given period of time
+
+To change the route they use
+
+* [Update Driver Route Stop](#update_driver_route_stop) for a given [Vehicle object id](#vehicle_object) and a given *Vehicle Route object id*
+
+To update details (entry points, notes) of the route stop they use
+
+* [Update Stop Geographic Details](#update_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
+
 ## Driver Route & Directions Start
 
 Motor freight carriers plan destinations and routes for their drivers and inform the drivers of the plan via the in-cab
@@ -420,47 +554,183 @@ components of a telematics system.
 
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
+Both personnel and semi-automated systems responsible for planning and assigning driver routes want to inform their
+drivers about their planned route before the driver starts the trip. They have
+
+* a [Vehicle object id](#vehicle_object) for a given vehicle
+
+To first check the vehicle for any faults or alarms in the past 24h they use
+
+* [Get Vehicle Flagged Events](#get_vehicle_flagged_events) for a given [Vehicle object id](#vehicle_object) over a given period of time
+
+Assuming the vehicle is good to go, then they send trip start and stop destinations to the driver along with any other
+instructions (such as which trailers to take) using
+
+* [Create a Vehicle Route](#create_a_vehicle_route) for a given [Vehicle object id](#vehicle_object)
+
+A successful creation of a route will yield a *Route object id* in the response to use in further updates or modifications
+to the route.
+
 ## Driver Route and Directions Done
 
 Motor freight carriers receive notifications when Drivers have completed their trip.
 
 This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
 
+Both personnel and semi-automated systems responsible for planning and assigning driver routes want to be notified of a
+completed trip, along with the driver information about duty on the trip. They have
+
+* a [Driver object id](#driver_object) for a given driver
+* and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) and may have optionally
+[updated the driver's Route Stop](#update_driver_route_stop) or [updated the *Stop Geographic Details*](#update_stop_geographic_details)
+they hence have both
+    * a *Vehicle Route object id* and
+    * a [Stop Geographic Details object id](#stop_geographic_details_object).
+
+To react to the route completions in 'real-time' they follow a feed using
+
+* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
+
+They mark trips completed based on matching a [Log Event object](#log_event_object) in the feed which matches a given
+[Driver object id](#driver_object) and also has a status indicating that the route is complete.
+
+At the end of trips they also query for any updates on changes to gates, access, repairs etc at the destination using
+
+* [Get Stop Geographic Details](#get_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
+
 ## Driver Messaging by Geo-Location
 
 Motor freight carriers use telematics systems to message their drivers for various reasons, not the least of which is to
 notify the drivers of dangerous weather conditions in their area.
 
+Personnel responsible for planning and assigning driver routes want to send messages to drivers in a particular
+geographic region. They have
+
+* a target geographic area, to which they want to send messages
+
+To determine which vehicles presently lie within the geographic area they get the current location of all fleet vehicles
+using
+
+* [Get Fleet Latest Locations](#get_fleet_latest_locations)
+
+Then, for each [Vehicle object id](#vehicle_object) which lies within the geographic area they send it a message using
+
+* [Send Message to a Vehicle](#send_message_to_a_vehicle) for a given [Vehicle object id](#vehicle_object)
+
 ## Driver Messaging by Vehicle
 
 Motor freight carriers also message their drivers by sending messages directly to a vehicle.
 
-## Vehicle Location Time History Tracking
+Personnel responsible for planning and assigning driver routes want to send a message to a driver's vehicle. They have
+
+* a [Vehicle object id](#vehicle_object) to which they wish to send a message
+
+they send the vehicle a message using
+
+* [Send Message to a Vehicle](#send_message_to_a_vehicle) for a given [Vehicle object id](#vehicle_object)
+
+## Vehicle Location Time History Processing
 
 Motor freight carriers use telematics fleet Location Time History for multiple 'fleet dynamics modeling' use cases such
-as: Fuel Purchase Prediction, Fuel Consumption Performance Tracking, and Fleet Maintenance Planning.
+as: Fuel Purchase Prediction, Fuel Consumption Performance Tracking, and Fleet Maintenance Planning. They have
+
+* a target time period, over which they want to perform an analysis of fleet location time history
+
+To perform the analysis on fleet location time history they use
+
+* [Get Fleet Location History](#get_fleet_location_history) for a given time period
 
 ## Human Resources Process: Payroll
 
 Motor freight carriers use telematics systems to assist in payroll processing. This enables efficiencies at scale that
 are important to modern motor freight carrier operations.
 
+Automated payroll/HR systems want to receive Log Events and convert these into payroll tracking entries.
+
+To do create payroll tracking entries in 'real-time' they follow the feed of [Log Events](#log_event_object) using
+
+* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
+
+furthermore -- if they operate in regions with specific break rules or waivers are applicable -- they use
+
+* [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) for each [Driver object id](#driver_object) in the
+feed for the times of interest to the payroll tracking entries
+
+In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
+this their systems send data _to_ the TSPs using
+
+* [Update Driver Duty Status](#update_driver_duty_status) endpoint for a given [Driver object id](#driver_object).
+
+and the duty status changes are reflected in the [Follow Fleet Log Events](#follow_fleet_log_events) endpoint.
+
+To associate their Driver's with metadata for use by the TSP (e.g. the region of governance for duty breaks and
+exemptions) they use
+
+* [Update Driver Info](#update_driver_info) for a given [Driver object id](#driver_object).
+
 ## Human Resources Process: Accident Report
 
 Motor freight carriers use telematics systems to monitor their fleets for accidents.
+
+Semi-automated systems want to receive notification of any accidents in their fleet and handle accident reports
+internally according to their own processes.
+
+To do respond to accidents in 'real-time' they follow the feed of [Log Events](#log_event_object) using
+
+* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
 
 ## Carrier Custom Business Intelligence
 
 Motor freight carriers use telematics systems for multiple, custom, business intelligence purposes where the overall
 health of their fleet is considered and fed into their own proprietary models.
 
+Automated and semi-automated analysis and reporting systems want to get the overall fleet health status for a particular
+time period.
+
+To process the fleet state over a target time period they use
+
+* [Get Fleet Vehicle Info](#get_fleet_vehicle_info) for a given time period
+
+To process and respond to fleet status in 'real-time' they follow a feed using
+
+* [Follow Fleet Vehicle Info](#follow_fleet_vehicle_info) for all vehicles
+
+To follow-up with queries of the hi-resolution time history of the fleet for a given time period they use
+
+* [Get Fleet Location History](#get_fleet_location_history) for a given time period.
+
 ## Compliance and Safety Monitoring
 
 Motor freight carriers use telematics systems to monitor compliance and safety for their operations.
 
+Personnel responsible for safety and compliance want to review the safety and compliance of their drivers. They have:
+
+* a [Driver object id](#driver_object) for a given driver
+* a time period of interest
+
+To obtain the information necessary to review for safety and compliance they use
+
+* [Get Driver Performance Summaries](#get_driver_performance_summaries) for a given [Driver object id](#driver_object) and for a given time period
+
+To create, delete and modify driver login credentials that the drivers will use in the
+field and to which the [Driver Performance Summary objects](#driver_performance_summary_object) are associate they use
+
+* [Update Driver TSP Portal Account](#update_driver_tsp_portal_account) for a given [Driver object id](#driver_object)
+
 ## In-Field Maintenance & Repair
 
 Motor freight carriers use telematics systems to plan (and react to) maintenance needs of their fleets.
+
+Automated back-end systems at the motor freight carrier want to be notified of any vehicle issues requiring maintenance.
+
+To determine which events require maintenance in 'real-time' they follow a feed using
+
+* [Follow Fleet Fault Code Events](#follow_fleet_fault_code_events) for all fleet vehicles
+
+To dispatch assitance to the location of a given [Vehicle object id](#vehicle_object) -- in the event that an issue
+requiring maintenance must be resolved in the field -- they obtain the most recent vehicle location using
+
+* [Get Vehicle Location History](#get_vehicle_location_history) for a given [Vehicle object id](#vehicle_object) over the most recent time period
 
 ## Data Structures
 
@@ -956,22 +1226,6 @@ data type defined below. If you change one you should probably also change the o
 
 # Group Use Case Check Provider State of Health
 
-Users of telematics that is highly integrated into their operations need assurances of the state of health of the
-Provider's services.
-
-The IT and operations staff responsible for system uptime want to query the Open Telematics API provider (TSP) Provider
-State of Health. They expect to receive either an 'all-clear' response indicating that the provider is not aware of any
-issues with its services at the moment of query or some details describing the contributing factors that have led to
-less than optimal operation.
-
-To check the current state of health of the service they use
-
-* [Check Current State of Health](#check_current_state_of_health)
-
-To check the past 30 days worth of states of health they use
-
-* [Check Past 30d State of Health](#check_past_30d_state_of_health)
-
 ## Check Current State of Health                               [GET /v1.0/health/current]
 <a id="check_current_state_of_health"></a>
 
@@ -1053,85 +1307,6 @@ Clients must treat any response other than code 200, code 401, or code 429 as eq
             Retry-After: {implementation-defined}
 
 # Group Use Case Data Export
-
-Motor freight carriers want to export all data from a TSP on a daily basis. Where 'all data' for the purposes of
-this specification is all the data specified here and does not include any other proprietary data structures designed
-and employed by the TSP. These data exports could be used by carriers to complete mandatory processes during times of
-TSP outage or to restore data -- although this last potential use is _not_ a use case we aim to support in OTAPI.
-
-***Data Import***
-
-The carriers would also like to be able to use the exported data in an 'import' to a second TSP or new instances of the
-same TSP. This is not an use case which this specification will attempt to support; however, we will aim to design the
-data structures such that any TSP wanting to implement _import_ is enabled to do so (c.f. 'Provider ID').
-
-***PII Separation***
-
-The carriers need to be able to deploy systems which do not touch PII -- as is treated in the Authorization section
-above. OTAPI implementations must provide for export of both [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format)
-and [Complete Telematics Export Format](#complete_telematics_export_format) objects so that systems which must be separated
-from PII can download the [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) type. As is
-noted in the access controls below, requests for these data types deny access by the *Vehicle X* roles.
-
-***Polling for Daily Files***
-
-The IT staff and automated systems that want to retreive the data exports on a daily basis will do so by polling the
-server for the status of the given's days complete record. The polling endpoint will either indicate that the file is
-not yet ready, or respond with a redirect to a location serving the complete file (statically).
-
-Implementors are free to make the files available for download from any service they choose. If the service hosting the
-files for download exposes endpoints under that of the OTAPI endpoints then the same authentication and authorization
-schemes must be enforced. If the files are made available for download elsewhere then they must not be made accessible
-without any authentication or authorization and the client is expected to be configured with the appropriate credentials
-for download independently of responses from the OTAPI server.
-
-***Time-base for Data Export***
-
-Note that the data export files will include both time-varying objects (those that have time associated with them) and
-also those that do not.
-
-* For time-varying objects: the files will only include whose associated time periods have an intesection with the
-requested time period (as per the details of the [Working With Dates](#working_with_dates) section above);
-
-* For non time-varying objects: the files will include all objects known to the TSP at the time of the request,
-regardless of the time period requested as defined by `start` and `stop` query parameters (included on the endpoints for
-API consistency under `/export/...`)
-
-Furthermore, the event and object times considered in the time queries for data export use *received times* (as opposed
-the default policy of relying on *creation times*). These are the times when the event or object was received, recorded
-and/or made available by the OTAPI server. This could pose problems for processing exported data for RODS compliance as
-multiple files may need to be processed in high-latency situations; however, the alternative is allow for data loss in
-the daily export files.
-
-***Complete Data Export***
-
-The *Complete* objects will contain sets of all of the following objects embedded, see [Complete Telematics Export Format](#complete_telematics_export_format) for more details.
-
-* [Vehicle](#vehicle_object)
-* [Vehicle Location Time](#vehicle_location_time_object)
-* [Vehicle Flagged Event](#vehicle_flagged_event_object)
-* [Vehicle Performance Event](#vehicle_performance_event_object)
-* [Stop Geographic Details](#stop_geographic_details_object)
-* [Vehicle Fault Code Event](#vehicle_fault_code_event_object)
-* [Driver](#driver_object)
-* [Log Event](#log_event_object)
-* [Region Specific Break Rules](#region_specific_break_rules_object)
-* [Region Specific Waivers](#region_specific_waivers_object)
-* [Driver Performance Summary](#driver_performance_summary_object)
-* [Message Receipt](#message_receipts)
-* [State of Health](#state_of_health_object)
-
-***Vehicle-Only Data Export***
-
-The *Vehicle-Only* objects will contain sets of all of the following objects embedded, see [Vehicle-Only Telematics Export Format](#vehicle_only_telematics_export_format) for more details.
-
-* [Vehicle](#vehicle_object)
-* [Vehicle Location Time](#vehicle_location_time_object)
-* [Vehicle Flagged Event](#vehicle_flagged_event_object)
-* [Vehicle Performance Event](#vehicle_performance_event_object)
-* [Stop Geographic Details](#stop_geographic_details_object)
-* [Vehicle Fault Code Event](#vehicle_fault_code_event_object)
-* [State of Health](#state_of_health_object)
 
 ## Complete Telematics Export Format                               [/v1.0/export/allrecords/status{?dayOf}]
 <a id="complete_telematics_export_format"></a>
@@ -1249,49 +1424,7 @@ ready then a `202` return code will be returned.
 
             Retry-After: {implementation-defined}
 
-# Group Use Case Generate Records of Duty Status for Compliance
-
-Motor freight carriers use telematics systems to maintain Record of Duty Status (RODS) compliance. The TSP to the
-carrier will supply compliant records directly, without the need for the carrier to use the OTAPI. The carrier may use
-OTAPI for RODS in the event that compliant records need to be produced when a TSP is no longer available. i.e. as a
-backup process only; however, to do so will require processing and it is not expected that OTAPI data be ready for
-compliance as-is. A couple examples; the `line data check` and `file data check` values will need to be calculated after
-the creation of line and files in the process of creating RODS files for compliance; OTAPI will not include these
-values. Also note that preparing compliance reports is a value added by TSPs; e.g. in at least one case, the ordering
-used by regulators used truncated timestamps and the higher-resolution available in the TSP RODS information led to
-events being out-of-order in the view of the regulators without special handling by the TSP. This is an example of the
-kinds of nuances that are handled by TPSs in their service offering and OTAPI is not meant to replace that service.
-
-Personnel responsible for compliance need to be able to create RODS based on information exported from OTAPI in the
-event a TSP is no longer available.
-
-See [Complete Telematics Export Format](#complete_telematics_export_format) for more details on the file format
-which should contain sufficient data for this use case in the array of [Log Event objects](#log_event_object).
-
 # Group Use Case Driver Availability
-
-Motor freight carriers need to understand the availability of their drivers -- within the current regulatory context of
-those drivers -- so that the carrier can ensure regulatory compliance and, more importantly, driver safety.
-
-Both personnel and semi-automated systems responsible for planning and assigning driver routes want to model the current
-availability of a Driver. They have
-
-* a [Driver object id](#driver_object) for a given driver
-
-To calculate the current driver availablity they retrieve 'driver availability factors' from which the current driver
-availability can be calculated using
-
-* [Get Driver Availability Factors](#get_driver_availability_factors) for a given [Driver object id](#driver_object) over a given period of time
-
-To consider also the breaks and exemption rules for driver in those logs (if they operate in regions with specific break
-rules or waivers) they use
-
-* [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) a given [Driver object id](#driver_object) over a given period of time
-
-In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
-this their systems send duty status changes to the TSP using
-
-* [Update Driver Duty Status](#update_driver_duty_status) for a given [Driver object id](#driver_object).
 
 ## Get Driver Availability Factors                             [GET /v1.0/drivers/{driverId}/availability_factors/{?startTime,stopTime}]
 <a id="get_driver_availability_factors"></a>
@@ -1487,34 +1620,6 @@ Clients can send custom-integrated duty status changes to the TSP to trigger dut
             Retry-After: {implementation-defined}
 
 # Group Use Case Driver Route & Directions Communication
-
-Motor freight carriers update their Driver's destination and route during their trip. This allows them to react to
-changing conditions in weather, the needs of regulatory restrictions on hours, optimizing follow-on activities after a
-trip, etc.
-
-This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
-
-Both personnel and semi-automated systems responsible for planning and assigning driver routes want to update the
-Driver's destination and route during a trip. They have
-
-* a [Driver object id](#driver_object) for a given driver
-* a [Vehicle object id](#vehicle_object) for a given vehicle
-* and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) they have both
-    * a *Vehicle Route object id* and
-    * a [Stop Geographic Details object id](#stop_geographic_details_object).
-
-To confirm that the given driver is still available to complete the route they retrieve the driver availability factors
-for the time period from the driver's start of route up until the present by using
-
-* [Get Driver Availability Factors](#get_driver_availability_factors) endpoint for a given [Driver object id](#driver_object) over a given period of time
-
-To change the route they use
-
-* [Update Driver Route Stop](#update_driver_route_stop) for a given [Vehicle object id](#vehicle_object) and a given *Vehicle Route object id*
-
-To update details (entry points, notes) of the route stop they use
-
-* [Update Stop Geographic Details](#update_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
 
 ## Update Driver Route Stop                                    [PUT /v1.0/vehicles/{vehicleId}/routes/{routeId}]
 <a id="update_driver_route_stop"></a>
@@ -1738,28 +1843,6 @@ any other routes using this stop will also be updated.
 
 # Group Use Case Driver Route & Directions Start
 
-Motor freight carriers plan destinations and routes for their drivers and inform the drivers of the plan via the in-cab
-components of a telematics system.
-
-This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
-
-Both personnel and semi-automated systems responsible for planning and assigning driver routes want to inform their
-drivers about their planned route before the driver starts the trip. They have
-
-* a [Vehicle object id](#vehicle_object) for a given vehicle
-
-To first check the vehicle for any faults or alarms in the past 24h they use
-
-* [Get Vehicle Flagged Events](#get_vehicle_flagged_events) for a given [Vehicle object id](#vehicle_object) over a given period of time
-
-Assuming the vehicle is good to go, then they send trip start and stop destinations to the driver along with any other
-instructions (such as which trailers to take) using
-
-* [Create a Vehicle Route](#create_a_vehicle_route) for a given [Vehicle object id](#vehicle_object)
-
-A successful creation of a route will yield a *Route object id* in the response to use in further updates or modifications
-to the route.
-
 ## Get Vehicle Flagged Events                                  [GET /v1.0/vehicles/{vehicleId}/flagged_events/{?startTime,stopTime}]
 <a id="get_vehicle_flagged_events"></a>
 
@@ -1923,31 +2006,6 @@ additional instructions in a *Externally Sourced Route Start Stop Details* objec
 
 # Group Use Case Driver Route and Directions Done
 
-Motor freight carriers receive notifications when Drivers have completed their trip.
-
-This feature is heavily used but also is commonly offered as an add-on to the TSP service from another party.
-
-Both personnel and semi-automated systems responsible for planning and assigning driver routes want to be notified of a
-completed trip, along with the driver information about duty on the trip. They have
-
-* a [Driver object id](#driver_object) for a given driver
-* and because they previously [created a *Vehicle Route*](#create_a_vehicle_route) and may have optionally
-[updated the driver's Route Stop](#update_driver_route_stop) or [updated the *Stop Geographic Details*](#update_stop_geographic_details)
-they hence have both
-    * a *Vehicle Route object id* and
-    * a [Stop Geographic Details object id](#stop_geographic_details_object).
-
-So that they can react to the route completing in 'real-time' they are following the feed of [Log Events](#log_event_object) using
-
-* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
-
-They mark trips completed based on matching a [Log Event object](#log_event_object) in the feed which matches a given
-[Driver object id](#driver_object) and also has a status indicating that the route is complete.
-
-At the end of trips they also query for any updates on changes to gates, access, repairs etc at the destination using
-
-* [Get Stop Geographic Details](#get_stop_geographic_details) for a given [Stop Geographic Details object id](#stop_geographic_details_object)
-
 ## Follow Fleet Log Events                                     [GET /v1.0/event_logs/feed{?token}]
 <a id="follow_fleet_log_events"></a>
 
@@ -1995,23 +2053,6 @@ polling an endpoint and providing a 'token' which evolves the window of new entr
             Retry-After: {implementation-defined}
 
 # Group Use Case Driver Messaging by Geo-Location
-
-Motor freight carriers use telematics systems to message their drivers for various reasons, not the least of which is to
-notify the drivers of dangerous weather conditions in their area.
-
-Personnel responsible for planning and assigning driver routes want to send messages to drivers in a particular
-geographic region. They have
-
-* a target geographic area, to which they want to send messages
-
-To determine which vehicles presently lie within the geographic area they get the current location of all fleet vehicles
-using
-
-* [Get Fleet Latest Locations](#get_fleet_latest_locations)
-
-Then, for each [Vehicle object id](#vehicle_object) which lies within the geographic area they send it a message using
-
-* [Send Message to a Vehicle](#send_message_to_a_vehicle) for a given [Vehicle object id](#vehicle_object)
 
 ## Get Fleet Latest Locations                                  [GET /v1.0/fleet/locations/latest{?page,count}]
 <a id="get_fleet_latest_locations"></a>
@@ -2133,27 +2174,7 @@ Clients can retrieve the (coarse) vehicle locations (of all vehicles) over a giv
 
 # Group Use Case Driver Messaging by Vehicle
 
-Motor freight carriers also message their drivers by sending messages directly to a vehicle.
-
-Personnel responsible for planning and assigning driver routes want to send a message to a driver's vehicle. They have
-
-* a [Vehicle object id](#vehicle_object) to which they wish to send a message
-
-they send the vehicle a message using
-
-* [Send Message to a Vehicle](#send_message_to_a_vehicle) for a given [Vehicle object id](#vehicle_object)
-
-
 # Group Use Case Vehicle Location Time History Processing
-
-Motor freight carriers use telematics fleet Location Time History for multiple 'fleet dynamics modeling' use cases such
-as: Fuel Purchase Prediction, Fuel Consumption Performance Tracking, and Fleet Maintenance Planning. They have
-
-* a target time period, over which they want to perform an analysis of fleet location time history
-
-To perform the analysis on fleet location time history they use
-
-* [Get Fleet Location History](#get_fleet_location_history) for a given time period
 
 ## Get Fleet Location History                                  [GET /v1.0/fleet/locations/{?startTime,stopTime,page,count}]
 <a id="get_fleet_location_history"></a>
@@ -2211,32 +2232,6 @@ To perform the analysis on fleet location time history they use
             Retry-After: {implementation-defined}
 
 # Group Use Case Human Resources Process: Payroll
-
-Motor freight carriers use telematics systems to assist in payroll processing. This enables efficiencies at scale that
-are important to modern motor freight carrier operations.
-
-Automated payroll/HR systems want to receive Log Events and convert these into payroll tracking entries.
-
-To do create payroll tracking entries in 'real-time' they follow the feed of [Log Events](#log_event_object) using
-
-* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
-
-furthermore -- if they operate in regions with specific break rules or waivers are applicable -- they use
-
-* [Get Driver Breaks and Waivers](#get_driver_breaks_and_waivers) for each [Driver object id](#driver_object) in the
-feed for the times of interest to the payroll tracking entries
-
-In some cases, facilities systems want to set the driver status in cases where they are on-duty but not driving. To do
-this their systems send data _to_ the TSPs using
-
-* [Update Driver Duty Status](#update_driver_duty_status) endpoint for a given [Driver object id](#driver_object).
-
-and the duty status changes are reflected in the [Follow Fleet Log Events](#follow_fleet_log_events) endpoint.
-
-To associate their Driver's with metadata for use by the TSP (e.g. the region of governance for duty breaks and
-exemptions) they use
-
-* [Update Driver Info](#update_driver_info) for a given [Driver object id](#driver_object).
 
 ## Update Driver Info                                        [PATCH /v1.0/drivers/{driverId}]
 <a id="update_driver_info"></a>
@@ -2326,34 +2321,7 @@ Clients can request updates to the TSP's managed user accounts for drivers by se
 
 # Group Use Case Human Resources Process: Accident Report
 
-Motor freight carriers use telematics systems to monitor their fleets for accidents.
-
-Semi-automated systems want to receive notification of any accidents in their fleet and handle accident reports
-internally according to their own processes.
-
-To do respond to accidents in 'real-time' they follow the feed of [Log Events](#log_event_object) using
-
-* [Follow Fleet Log Events](#follow_fleet_log_events) for all drivers
-
 # Group Use Case Carrier Custom Business Intelligence
-
-Motor freight carriers use telematics systems for multiple, custom, business intelligence purposes where the overall
-health of their fleet is considered and fed into their own proprietary models.
-
-Automated and semi-automated analysis and reporting systems want to get the overall fleet health status for a particular
-time period.
-
-To process the fleet state over a target time period they use
-
-* [Get Fleet Vehicle Info](#get_fleet_vehicle_info) for a given time period
-
-To process and respond to fleet status in 'real-time' they follow a feed using
-
-* [Follow Fleet Vehicle Info](#follow_fleet_vehicle_info) for all vehicles
-
-To follow-up with queries of the hi-resolution time history of the fleet for a given time period they use
-
-* [Get Fleet Location History](#get_fleet_location_history) for a given time period.
 
 ## Get Fleet Vehicle Info                                      [GET /v1.0/fleet/infos/{?startTime,stopTime}]
 <a id="get_fleet_vehicle_info"></a>
@@ -2463,22 +2431,6 @@ entries with each query in the polling.
             Retry-After: {implementation-defined}
 
 # Group Use Case Compliance and Safety Monitoring
-
-Motor freight carriers use telematics systems to monitor compliance and safety for their operations.
-
-Personnel responsible for safety and compliance want to review the safety and compliance of their drivers. They have:
-
-* a [Driver object id](#driver_object) for a given driver
-* a time period of interest
-
-To obtain the information necessary to review for safety and compliance they use
-
-* [Get Driver Performance Summaries](#get_driver_performance_summaries) for a given [Driver object id](#driver_object) and for a given time period
-
-To create, delete and modify driver login credentials that the drivers will use in the
-field and to which the [Driver Performance Summary objects](#driver_performance_summary_object) are associate they use
-
-* [Update Driver TSP Portal Account](#update_driver_tsp_portal_account) for a given [Driver object id](#driver_object)
 
 ## Get Driver Performance Summaries                            [GET /v1.0/drivers/{driverId}/performance_summaries/{?startTime,stopTime}]
 <a id="get_driver_performance_summaries"></a>
@@ -2605,19 +2557,6 @@ Clients can request updates to the TSP's portal user accounts for drivers by sen
             Retry-After: {implementation-defined}
 
 # Group Use Case In-Field Maintenance & Repair
-
-Motor freight carriers use telematics systems to plan (and react to) maintenance needs of their fleets.
-
-Automated back-end systems at the motor freight carrier want to be notified of any vehicle issues requiring maintenance.
-
-To determine which events require maintenance in 'real-time' they follow a feed using
-
-* [Follow Fleet Fault Code Events](#follow_fleet_fault_code_events) for all fleet vehicles
-
-To dispatch assitance to the location of a given [Vehicle object id](#vehicle_object) -- in the event that an issue
-requiring maintenance must be resolved in the field -- they obtain the most recent vehicle location using
-
-* [Get Vehicle Location History](#get_vehicle_location_history) for a given [Vehicle object id](#vehicle_object) over the most recent time period
 
 ## Follow Fleet Fault Code Events                              [GET /v1.0/fleet/faults/feed{?token}]
 <a id="follow_fleet_fault_code_events"></a>

--- a/apiary.apib
+++ b/apiary.apib
@@ -354,9 +354,13 @@ The Open Telematics API is ready to be used in locales other than the United Sta
 display and interpretation of data in languages other English (US, `en_US`) implementors may provide translations of the
 descriptions of the enumerated constants in the API.
 
-The localization does not apply to units of measure. With the exception of velocities where units of `km/h` are used,
-the Open Telematics API will use SI units. Nor does the localization apply to arbitrary strings in data objects of the
-API such as messages for display in vehicles or comment fields.
+The localization does not apply to units of measure. Open Telematics API will use SI units with the following exceptions:
+
+* velocities where units of `km/h` are used
+* [Log Event objects](#log_event_object) where units of either miles or kilometres are used (but not both)
+
+The localization also does not apply to arbitrary strings in data objects of the API such as messages for display in
+vehicles or comment fields.
 
 Requests to the Translation `/i18n` endpoint (see below for more details) shall include the request header `Accept-
 Language: `. If no request header is present then `Accept-Language: en` will be assumed.

--- a/generateme.sh
+++ b/generateme.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+APIB_FILE=apiary.apib
+HTML_FILE=otapi.html
+PDF_FILE=otapi.pdf
+
+CHROME='/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'
+
+aglio -t otto --theme-full-width -i "${APIB_FILE}" -o "${HTML_FILE}"
+# for default theme
+#sed -e 's/collapse-button"/collapse-button show"/g' -i'' "${HTML_FILE}"
+# for otto them
+sed -e 's/class="collapse-content"/class="collapse-content" style="display: inline;"/g' -i'' "${HTML_FILE}"
+
+
+# not working yet
+#"${CHROME}" --headless --disable-gpu --hide-scrollbars --print-to-pdf "${HTML_FILE}"

--- a/generateme.sh
+++ b/generateme.sh
@@ -6,12 +6,7 @@ PDF_FILE=otapi.pdf
 
 CHROME='/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'
 
-aglio -t otto --theme-full-width -i "${APIB_FILE}" -o "${HTML_FILE}"
-# for default theme
-#sed -e 's/collapse-button"/collapse-button show"/g' -i'' "${HTML_FILE}"
-# for otto them
-sed -e 's/class="collapse-content"/class="collapse-content" style="display: inline;"/g' -i'' "${HTML_FILE}"
-
+aglio -t olio-printing --theme-full-width -i "${APIB_FILE}" -o "${HTML_FILE}"
 
 # not working yet
 #"${CHROME}" --headless --disable-gpu --hide-scrollbars --print-to-pdf "${HTML_FILE}"


### PR DESCRIPTION
Some larger changes are collected here. The following issues are addressed in this changeset:

* `Performance Thresholds` object does not need to be retrievable via id in progress -- #133
* Spurious 'Get' on action names in progress -- #131
* error status return codes should all have descriptive bodies in progress -- #130
* Log Events and unit conversion Notes attention wanted in progress -- #127
* Include speed change event recording attention wanted in progress -- #114
* TSP latency reporting attention wanted in progress -- #110 
* add section anchors and then also xref sections in progress -- #50 

I've updated the preview site: https://app.apiary.io/previewotapi/editor ; see the 'files changed' tab for details.

These changes are not intended to be made for the may prototype; the version of this API for the prototype was frozen at tag https://github.com/nmfta-repo/nmfta-opentelematics-api/releases/tag/protoype-0.1rc.3